### PR TITLE
Prettier print git count line

### DIFF
--- a/shell/git-count-line.sh
+++ b/shell/git-count-line.sh
@@ -22,5 +22,5 @@ git --git-dir=$DIRECTORY/.git log --author="$AUTHOR_NAME" \
 --after="$BEGIN" --before="$END" \
 --pretty=tformat: --numstat \
 | awk '{ add += $1 ; subs += $2 ; loc += $1 - $2 } \
-END { printf "added lines: %s removed lines : \
-%s total lines: %s\n",add,subs,loc }'
+END { printf "added lines: %s\nremoved lines: \
+%s\ntotal lines: %s\n",add,subs,loc }'

--- a/shell/git-tag-with-logs.sh
+++ b/shell/git-tag-with-logs.sh
@@ -78,7 +78,8 @@ if [ "$tagname" == "" ]; then
   exit 1;
 fi
 
-gitcmd="git -C $dir tag --create-reflog"
+# gitcmd="git -C $dir tag --create-reflog"
+gitcmd="git -C $dir tag"
 
 # enable signing
 if [[ $enablesign -ne 0 ]]; then


### PR DESCRIPTION
## Summary by Sourcery

Enhance the readability of the git-count-line.sh script output by formatting the printed lines with newlines and remove the --create-reflog option from the git tag command in the git-tag-with-logs.sh script.

Enhancements:
- Improve the readability of the output in the git-count-line.sh script by formatting the printed lines with newlines.

Chores:
- Remove the --create-reflog option from the git tag command in the git-tag-with-logs.sh script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved output format for line count summary in `git-count-line.sh`, providing clearer metrics for added, removed, and total lines.
	- Streamlined tag creation process in `git-tag-with-logs.sh`, simplifying the command and enhancing usability while retaining logging functionality.

- **Documentation**
	- Added comments in `git-tag-with-logs.sh` for better clarity on command usage and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->