### PR TITLE
Add minimal MCP server skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 .DS_Store
 .Trash
 node_modules/
+
+# MCP build artifacts
+mcp/cmd/someuseful-mcp/someuseful-mcp
+mcp/cmd/someuseful-mcp/__debug_bin*
+
+# IDE
+.codex/
+.cursor/
+.idea/
+.gemini/
+.opencode/
+.trae/
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # SomeUsefulShellScripts
 Some utils using shell/python/perl scripts.
+
+## Layout
+
+- `shell/`: active shell utilities
+- `docs/`: inventory and migration planning
+- `archive/`: planned archive area for deprecated scripts
+- `mcp/`: minimal MCP server skeleton for agent-facing tools

--- a/archive/MIGRATION.md
+++ b/archive/MIGRATION.md
@@ -1,0 +1,88 @@
+# archive/ 迁移清单
+
+本文档用于管理“从活跃脚本区迁移到归档区”的第一批动作。
+
+目标不是一次性删光旧脚本，而是把这些脚本明确标记为：
+
+- 仅保留历史参考价值；
+- 不再作为主维护对象；
+- 不参与后续 `MCP` / `Skill` 能力建设。
+
+## 迁移规则
+
+- 迁移后保留原始文件名，降低历史检索成本。
+- 第一阶段只移动“示例性、过时性、过窄用途”的脚本。
+- 迁移前不要顺手重写逻辑，避免归档动作和功能改造混在一起。
+- 如脚本仍被其他脚本引用，先在本清单中标记 `defer`，暂不迁移。
+
+## 建议目录
+
+建议归档目标路径如下：
+
+```text
+archive/
+  MIGRATION.md
+  shell/
+```
+
+后续实际迁移时，将待归档脚本移动到 `archive/shell/`。
+
+## 第一批建议归档
+
+### Ready now
+
+- [ ] `shell/docker-change-brew-mirror.sh` -> `archive/shell/docker-change-brew-mirror.sh`
+  - 原因：镜像源逻辑已过时，脚本本身也提示 deprecated。
+- [ ] `shell/gh-post-release-example.sh` -> `archive/shell/gh-post-release-example.sh`
+  - 原因：更像历史示例，不是稳定工具。
+- [ ] `shell/mv-cpp-2-mm.sh` -> `archive/shell/mv-cpp-2-mm.sh`
+  - 原因：用途过窄，且实现方式脆弱。
+- [ ] `shell/pandoc-insert-images-demo.sh` -> `archive/shell/pandoc-insert-images-demo.sh`
+  - 原因：属于 demo 脚本，不适合作为活跃工具维护。
+
+### Archive after confirmation
+
+- [ ] `shell/rm-bash-comments.sh` -> `archive/shell/rm-bash-comments.sh`
+  - 原因：价值较低，且当前实现存在参数判断 bug。
+  - 说明：如果你还偶尔会用它，可先修好再归档；否则直接归档也可以。
+
+## 暂不归档
+
+下面这些虽然要重写，但不建议直接归档，因为它们仍有明显演进价值：
+
+- `shell/go-list-dep.sh`
+- `shell/git-count-line.sh`
+- `shell/git-find-large-files.sh`
+- `shell/git-status-subdir.sh`
+- `shell/docker-show-images-arch.sh`
+- `shell/watch-prog-memory.sh`
+- `shell/git-tag-with-logs.sh`
+- `shell/gh-upload-release.sh`
+- `shell/gh-delete-oudate-actions.sh`
+
+## 实施前检查
+
+在真正执行迁移前，建议逐项确认：
+
+- [ ] 当前分支不是主分支
+- [ ] 工作区已清理或已分步提交
+- [ ] 没有其它脚本直接 `source` 或调用待迁移文件
+- [ ] `README` 或文档中不存在仍指向旧位置的说明
+
+## 实施顺序
+
+建议的迁移顺序：
+
+1. 创建 `archive/shell/`
+2. 迁移 `Ready now` 列表
+3. 修正文档中的路径引用
+4. 单独提交一次归档 commit
+
+## 归档 commit message 建议
+
+可使用类似 message：
+
+```text
+chore: archive deprecated and example shell scripts
+```
+

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,228 @@
+# Skills / MCP 迁移计划
+
+## 结论先行
+
+对这个仓库，建议采用：
+
+`本地稳定 CLI -> MCP -> Skills`
+
+而不是：
+
+- 直接把 Bash 脚本塞进 skill；
+- 或者直接把所有脚本包成 MCP。
+
+原因：
+
+- 你的脚本里混合了“只读工具”“危险动作”“环境初始化”“个人 workflow”四种形态。
+- `MCP` 适合工具；`Skill` 适合流程、判断、注意事项和保守操作。
+- 如果底层 CLI 没有先收敛，后面不管做 MCP 还是 skill，都会变成把脆弱性包装一层再暴露出去。
+
+## 目标架构
+
+建议演进为下面四层：
+
+1. `bin/` 或 `cmd/`
+   - 存放稳定 CLI。
+   - 每个命令都要有一致参数风格、明确退出码、可机器解析输出。
+2. `internal/` 或 `lib/`
+   - 放共享逻辑，避免多个脚本重复拼 `git`、`docker`、`kubectl` 命令。
+3. `mcp/`
+   - 暴露只读或低风险工具给 OpenClaw / 其它 Agent。
+4. `skills/`
+   - 暴露“什么时候该调用什么工具、哪些操作必须确认、失败如何回退”。
+
+## 工具设计约束
+
+所有计划继续演进的脚本，建议统一到下面契约：
+
+- 支持 `--help`
+- 支持 `--json`
+- 支持 `--dry-run`（凡是有副作用的命令都应支持）
+- stdout 输出结果，stderr 输出诊断
+- 非零退出码只表达失败，不混杂业务状态
+- 不依赖隐式当前目录；尽量显式传参
+- 不在运行时自动安装依赖
+- 不使用 `eval`
+
+## 分阶段计划
+
+### Phase 0：整理与冻结
+
+先做仓库卫生，而不是先上协议层。
+
+建议动作：
+
+- 建立脚本 inventory，并固定分级口径。
+- 给仓库加一个最小目录规划：
+  - `archive/`
+  - `docs/`
+  - `bin/`
+  - `mcp/`
+  - `skills/`
+- 把明显过时或示例性质脚本移入 `archive/`。
+
+这一阶段的目标是“减少噪音”。
+
+### Phase 1：重写第一批稳定 CLI
+
+建议首批只做只读、低风险脚本：
+
+- `shell/go-list-dep.sh`
+- `shell/git-count-line.sh`
+- `shell/git-find-large-files.sh`
+- `shell/git-status-subdir.sh`
+- `shell/docker-show-images-arch.sh`
+- `shell/watch-prog-memory.sh`
+
+建议输出风格示例：
+
+```json
+{
+  "ok": true,
+  "data": []
+}
+```
+
+这里不要求你一开始就把它们改成 Go；Bash 也行，只要契约稳定。
+但如果某个命令逻辑已经比较复杂，优先用 Go 重写更稳。
+
+### Phase 2：做只读 MCP Server
+
+MCP 第一阶段只暴露以下类型：
+
+- git 统计/查询
+- docker 镜像与容器信息查询
+- 进程资源观测
+- 目录与文件体积分析
+
+不要在第一阶段暴露：
+
+- 删除分支
+- 改 git 历史
+- 删除容器/镜像
+- 修改 kubeconfig
+- 导出私钥
+- 强制 finalize namespace
+
+MCP tool 命名建议统一前缀：
+
+- `git_count_lines`
+- `git_find_large_files`
+- `git_status_subdirs`
+- `docker_show_images_arch`
+- `watch_program_memory`
+- `du_directory`
+
+## Skills 设计建议
+
+你的 skill 不应该只是“帮我调用脚本”，而应沉淀为：
+
+- 哪些仓库适合执行；
+- 执行前检查什么；
+- 什么情况先 `dry-run`；
+- 什么情况禁止自动执行；
+- 失败后如何回退；
+- 如何解释结果给用户。
+
+建议首批做 3 个 skill：
+
+1. `git-maintainer`
+   - 负责仓库统计、分支清理建议、对象体积分析、状态巡检。
+2. `github-release-ops`
+   - 负责 tag、release、产物上传、Actions 清理。
+3. `k8s-ops-guarded`
+   - 负责 kubeconfig 合并、镜像搬运指令生成、危险操作确认。
+
+## High-risk 列表
+
+下面这些能力即使未来要开放，也应至少满足：
+
+- `--dry-run`
+- 二次确认
+- 明确 impact 提示
+- 日志留痕
+
+对象如下：
+
+- `shell/eth-keystore-2-privatekey.sh`
+- `shell/k8s-delete-stuck-ns.sh`
+- `shell/git-rm-object.sh`
+- `shell/git-delete-merge-branch.sh`
+- `shell/git-clean-after-rm.sh`
+- `shell/git-lean.sh`
+- `shell/git-untrack-remote-branch.sh`
+- `shell/docker-rm-dangling-images.sh`
+- `shell/docker-rm-exited-containers.sh`
+
+在这之前，它们默认归类为 `Local-only`。
+
+## 为什么不是“只做 Skills”
+
+只做 skill 的问题是：
+
+- 跨 Agent 可移植性差；
+- 工具输出不结构化；
+- 长期会把经验和执行耦合在一起；
+- 一旦 Agent 换平台，复用价值会下降。
+
+## 为什么也不是“只做 MCP”
+
+只做 MCP 的问题是：
+
+- 很多脚本其实是流程，不是工具；
+- 高风险操作需要保守规则，不只是参数 schema；
+- 你的个人环境假设很多，直接公开工具会放大误用概率。
+
+## 对“大公司现成 skills 已经够用了”的判断
+
+不是。
+
+更准确的说法是：
+
+- 通用技能，大厂生态已经越来越成熟；
+- 私有 workflow，仍然要靠你自己沉淀。
+
+你的仓库恰恰大多属于后者：
+
+- 本地环境治理；
+- Git/GitHub 维护习惯；
+- K8s 运维捷径；
+- 发布流程；
+- 私有目录布局假设。
+
+这些内容不会被 Anthropic、OpenAI 或其它平台替你完整抽象掉。
+
+## 最近两周可执行版本
+
+如果只做一个现实、克制的两周计划，建议是：
+
+### Week 1
+
+- 补齐 `docs/script-inventory.md`
+- 归档过时脚本
+- 统一首批 3 个只读脚本接口
+  - `go-list-dep`
+  - `git-count-line`
+  - `git-find-large-files`
+
+### Week 2
+
+- 再统一 3 个只读脚本接口
+  - `git-status-subdir`
+  - `docker-show-images-arch`
+  - `watch-prog-memory`
+- 起一个最小 MCP server
+- 把 `git-maintainer` skill 写出来，先只接只读工具
+
+## 建议的仓库方向
+
+如果你打算长期维护，建议最终把仓库从“脚本收集箱”改成“个人 Agent 工具底座”：
+
+- `archive/` 放历史脚本
+- `bin/` 放稳定 CLI
+- `mcp/` 放跨 Agent 工具协议层
+- `skills/` 放经验和流程
+- `docs/` 放 inventory、风险约定、迁移计划
+
+这样以后不管你接 OpenClaw、Claude Code、Codex CLI，还是别的 Agent，都能复用同一套底层能力。
+

--- a/docs/script-inventory.md
+++ b/docs/script-inventory.md
@@ -1,0 +1,113 @@
+# 脚本清单与分级
+
+本文档用于给当前仓库中的脚本做一次可迁移、可治理的盘点，目标不是“评判脚本好坏”，而是回答三个问题：
+
+1. 这个脚本值不值得继续维护。
+2. 它更适合沉淀为 `skill`、`MCP tool`，还是仅保留本地使用。
+3. 在迁移前是否必须先重写。
+
+## 判定标准
+
+- `风险`
+  - `L`：只读或低破坏性。
+  - `M`：会修改本地环境、仓库状态或远端资源，但通常可控。
+  - `H`：删除、重写历史、改集群状态、涉及密钥等高风险操作。
+- `现状`
+  - `keep`：可继续保留。
+  - `rewrite`：保留思路，但建议先重写。
+  - `archive`：更适合归档或仅作为历史参考。
+- `建议去向`
+  - `MCP`：适合暴露给 OpenClaw 或其它 Agent 的结构化工具。
+  - `Skill`：适合保留为流程编排、经验和操作准则。
+  - `Local-only`：仅本机手工使用，不建议开放给通用 Agent。
+  - `Archive`：归档，不再继续演进。
+
+## 总体判断
+
+- 当前仓库更像“个人运维脚本盒”，还不是稳定工具产品。
+- `git` 脚本数量最多，也是最值得优先整理的一组。
+- 高风险脚本不适合直接变成 MCP；应先收口为本地受控命令，必要时再由 skill 进行强确认包装。
+- 真正适合先做 MCP 的，是一批只读、结构化、输出明确的脚本。
+
+## 支撑文件
+
+- `js/keystore-to-privatekey/main.js` 是 `shell/eth-keystore-2-privatekey.sh` 的依赖实现。
+- 这个 JS 子目录属于“配套工具”，不建议单独暴露；应连同外层脚本一起重构和控权。
+
+## Inventory
+
+| 脚本 | 领域 | 当前作用 | 主要依赖 | 风险 | 现状 | 建议去向 | 备注 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `shell/curl-time.sh` | shell/curl | 向 rc 文件追加 `timecurl` alias | `grep`, `curl` | M | rewrite | Skill | 更像环境初始化片段，不像长期工具 |
+| `shell/docker-change-brew-mirror.sh` | docker/homebrew | 切换 Docker Homebrew 镜像 | `git`, `brew` 语义 | M | archive | Archive | 镜像源已过时，脚本自己也提示 deprecated |
+| `shell/docker-rm-dangling-images.sh` | docker | 删除 dangling images | `docker` | H | keep | Local-only | 破坏性明确，可做受控本地命令 |
+| `shell/docker-rm-exited-containers.sh` | docker | 删除 exited containers | `docker` | H | keep | Local-only | 同上 |
+| `shell/docker-show-containers-command.sh` | docker | 查看容器启动命令 | `docker` | L | rewrite | MCP | 适合改成结构化只读工具 |
+| `shell/docker-show-images-arch.sh` | docker | 查看镜像架构 | `docker` | L | rewrite | MCP | 非常适合先做 MCP |
+| `shell/du-dir.sh` | filesystem | 查看目录体积 | `du`, `sort` | L | rewrite | MCP | 需要修复 glob/空目录兼容性 |
+| `shell/eth-keystore-2-privatekey.sh` | ethereum | keystore 导出私钥 | `node`, `npm` | H | rewrite | Local-only | 涉及私钥，不建议暴露给通用 Agent |
+| `shell/gh-delete-oudate-actions.sh` | GitHub Actions | 删除过期 workflow runs | `gh` | H | rewrite | Skill | 需要分页、dry-run、确认机制 |
+| `shell/gh-post-release-example.sh` | GitHub release | tag push 后构建并上传 release | `make`, `gh-upload-release.sh` | M | archive | Archive | 更像历史示例，不像通用工具 |
+| `shell/gh-upload-release.sh` | GitHub release | 创建 release 并上传产物 | `git`, `github-release`, `go` | H | rewrite | Skill | 逻辑有价值，但实现老旧且有 `eval` 风险 |
+| `shell/git-clean-after-rm.sh` | git maintenance | 清理 refs/reflog/gc | `git` | H | keep | Local-only | 可保留为手工维护命令 |
+| `shell/git-clean-cursor-worktrees.sh` | git/cursor | 清理 Cursor worktrees 与分支 | `find`, `git`, `rm` | H | rewrite | Skill | 强个人环境假设，不适合直接 MCP |
+| `shell/git-count-line.sh` | git analytics | 按时间和作者统计增删行数 | `git`, `awk` | L | rewrite | MCP | 很适合作为只读统计工具 |
+| `shell/git-delete-merge-branch.sh` | git branch | 删除已 gone 的本地分支 | `git`, `grep`, `awk` | H | keep | Local-only | 可加 dry-run，但不建议先开放 |
+| `shell/git-find-large-files.sh` | git analysis | 查找仓库大文件 | `git`, `sed`, `sort`, `numfmt` | L | rewrite | MCP | 值得优先整理 |
+| `shell/git-lean.sh` | git maintenance | git repack/gc/fsck | `git` | H | keep | Local-only | 本地维护价值大，通用 Agent 风险高 |
+| `shell/git-pull-all-subdir.sh` | git batch ops | 批量拉取子目录仓库 | `find`, `git` | M | rewrite | Skill | 适合流程型能力，不适合裸暴露 |
+| `shell/git-push-hook-wrap.sh` | git workflow | push 前后触发自定义 hook | `git` | M | keep | Skill | 更适合作为 workflow 片段 |
+| `shell/git-push-new-branch.sh` | git workflow | 推送当前分支并设置 upstream | `git` | M | keep | Skill | 太薄，不必单独做 MCP |
+| `shell/git-rm-object.sh` | git history rewrite | 从历史移除文件对象 | `git filter-branch` | H | rewrite | Local-only | 高风险且实现老旧，应谨慎替换为更现代方案 |
+| `shell/git-status-subdir.sh` | git batch ops | 批量查看子目录仓库状态 | `find`, `git` | L | rewrite | MCP | 适合产出 JSON 的只读工具 |
+| `shell/git-tag-with-logs.sh` | git release | 创建 tag，并带提交日志 | `git` | H | rewrite | Skill | 很像 release workflow 的核心步骤 |
+| `shell/git-untrack-remote-branch.sh` | git maintenance | 删除 remote tracking branches | `git`, `grep`, `xargs` | H | keep | Local-only | 建议后续补 dry-run，但不先开放 |
+| `shell/go-list-dep.sh` | golang | 列出依赖与测试依赖 | `go`, `xargs` | L | keep | MCP | 已经很接近一个成熟只读工具 |
+| `shell/k8s-delete-stuck-ns.sh` | kubernetes | 强制删除卡住 namespace | `kubectl`, `sed` | H | keep | Local-only | 破坏性极强，不建议直接给 Agent |
+| `shell/k8s-merge-config.sh` | kubernetes | 合并 kubeconfig | `kubectl` | M | rewrite | Skill | 涉及写配置文件，更适合受控流程 |
+| `shell/mv-cpp-2-mm.sh` | filesystem | 批量改后缀名 | `ls`, `mv` | M | archive | Archive | 太窄、实现脆弱、价值不高 |
+| `shell/pandoc-insert-images-demo.sh` | pandoc/demo | ProGit demo 文本替换 | `perl` | M | archive | Archive | 更像示例，不像长期资产 |
+| `shell/pandoc-md-2-epub.sh` | pandoc | 合并 markdown 生成 epub | `pandoc`, `ls` | M | rewrite | Skill | 可做文档 workflow，但不必优先 |
+| `shell/pandoc-md-2-epub3.sh` | pandoc | 合并 markdown 生成 epub3 | `pandoc`, `ls` | M | rewrite | Skill | 同上 |
+| `shell/pull-k8s-docker-images.sh` | kubernetes/images | 生成镜像拉取、tag、push 指令 | `kubeadm`, `docker` | M | rewrite | Skill | 更适合“离线拉镜像操作指南” skill |
+| `shell/rm-bash-comments.sh` | text | 删除 bash 注释 | `grep` | L | rewrite | Archive | 价值低，且当前参数判断有 bug |
+| `shell/rm-mac-empty-dir.sh` | filesystem | 删除 `.DS_Store` 和空目录 | `find` | H | keep | Local-only | 本地清理有用，但不宜开放 |
+| `shell/watch-prog-memory.sh` | observability | 周期记录程序内存占用 | `pidstat`, `awk` | L | rewrite | MCP | 适合改造成结构化观测工具 |
+
+## 首批迁移优先级
+
+优先迁移这 6 个：
+
+1. `shell/go-list-dep.sh`
+2. `shell/git-count-line.sh`
+3. `shell/git-find-large-files.sh`
+4. `shell/git-status-subdir.sh`
+5. `shell/docker-show-images-arch.sh`
+6. `shell/watch-prog-memory.sh`
+
+原因：
+
+- 都偏只读。
+- 输入输出容易结构化。
+- 对 OpenClaw / Claude Code / 其它 Agent 的复用价值较高。
+- 风险相对可控，适合作为第一批 MCP 工具。
+
+## 不建议先开放的脚本
+
+下面这些即使重写，也不建议第一阶段开放为 MCP：
+
+- `shell/eth-keystore-2-privatekey.sh`
+- `shell/k8s-delete-stuck-ns.sh`
+- `shell/git-rm-object.sh`
+- `shell/git-delete-merge-branch.sh`
+- `shell/git-clean-after-rm.sh`
+- `shell/git-lean.sh`
+- `shell/git-untrack-remote-branch.sh`
+- `shell/docker-rm-dangling-images.sh`
+- `shell/docker-rm-exited-containers.sh`
+
+它们可以继续作为：
+
+- 本地手工命令；
+- 或者仅被带强确认的 skill 间接调用。
+

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,9 +2,10 @@
 
 这是当前仓库的最小 MCP 骨架，目标是先把低风险、结构化、可组合的能力挂出来，再逐步扩展更多工具。
 
-当前仅暴露一个 tool：
+当前暴露两个 tool：
 
 - `go_list_dep`
+- `git_count_line`
 
 ## 特点
 
@@ -107,6 +108,8 @@ openclaw agent \
   - 显式指定仓库根目录。
 - `SUSS_GO_LIST_DEP_SCRIPT`
   - 显式指定 `go-list-dep` 脚本路径。
+- `SUSS_GIT_COUNT_LINE_SCRIPT`
+  - 显式指定 `git-count-line.sh` 脚本路径。
 
 如果两者都不传，服务会优先尝试：
 
@@ -133,6 +136,32 @@ openclaw agent \
 - `includeStdlib`
 - `testImportDepth`
 - `dependencies`
+
+## Tool: `git_count_line`
+
+输入参数：
+
+- `beginDate`
+  - `string`，必填，例如 `2024-01-01`
+- `endDate`
+  - `string`，必填，例如 `2026-01-01`
+- `directory`
+  - `string`，可选，默认 `"."`
+- `authorName`
+  - `string`，可选，默认取 `git config user.name`
+- `workingDirectory`
+  - `string`，可选，用于指定底层脚本的启动目录
+
+输出：
+
+- `ok`
+- `beginDate`
+- `endDate`
+- `directory`
+- `authorName`
+- `addedLines`
+- `removedLines`
+- `totalLines`
 
 ## 设计取舍
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,60 @@
+# SomeUsefulShellScripts MCP
+
+这是当前仓库的最小 MCP 骨架，目标是先把低风险、结构化、可组合的能力挂出来，再逐步扩展更多工具。
+
+当前仅暴露一个 tool：
+
+- `go_list_dep`
+
+## 特点
+
+- 使用 `stdio` 传输，适合本地被 Agent 进程拉起。
+- 不依赖第三方 SDK，便于在当前仓库中快速验证和维护。
+- 当前通过调用 `shell/go-list-dep.sh` 提供能力，后续可以逐步把底层脚本替换成更稳定的实现。
+
+## 运行
+
+```bash
+cd mcp
+go run ./cmd/someuseful-mcp
+```
+
+## 可选环境变量
+
+- `SUSS_REPO_ROOT`
+  - 显式指定仓库根目录。
+- `SUSS_GO_LIST_DEP_SCRIPT`
+  - 显式指定 `go-list-dep` 脚本路径。
+
+如果两者都不传，服务会优先尝试：
+
+1. 当前目录所在 git 仓库根目录下的 `shell/go-list-dep.sh`
+2. 当前工作目录附近的常见相对路径
+
+## Tool: `go_list_dep`
+
+输入参数：
+
+- `packages`
+  - `string[]`，可选，默认 `["."]`
+- `includeStdlib`
+  - `boolean`，可选，默认 `false`
+- `testImportDepth`
+  - `integer`，可选，默认 `1`
+- `workingDirectory`
+  - `string`，可选，用于指定执行 `go list` 时的工作目录
+
+输出：
+
+- `ok`
+- `packages`
+- `includeStdlib`
+- `testImportDepth`
+- `dependencies`
+
+## 设计取舍
+
+- 当前先不引入 tasks、resources、prompts。
+- 当前先不做批量高风险操作，只暴露只读工具。
+- 当前先保留 Bash 作为执行层，后续如果某个工具复杂度上来，再换成 Go 实现。
+

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -19,6 +19,88 @@ cd mcp
 go run ./cmd/someuseful-mcp
 ```
 
+## 接入示例
+
+### Claude Code
+
+如果你希望把这个 MCP 作为当前项目的共享配置写入 `.mcp.json`，可以在仓库根目录执行：
+
+```bash
+cd /absolute/path/to/SomeUsefulShellScripts
+
+claude mcp add --transport stdio --scope project \
+  -e SUSS_REPO_ROOT="$PWD" \
+  someuseful-shell-scripts -- \
+  go run "$PWD/mcp/cmd/someuseful-mcp"
+```
+
+执行后可以用下面的命令确认是否已注册：
+
+```bash
+claude mcp list
+```
+
+进入 Claude Code 后，也可以通过 `/mcp` 查看服务器状态。
+
+如果你更希望手工维护项目级 `.mcp.json`，可以参考下面的最小示例：
+
+```json
+{
+  "mcpServers": {
+    "someuseful-shell-scripts": {
+      "command": "go",
+      "args": [
+        "run",
+        "/absolute/path/to/SomeUsefulShellScripts/mcp/cmd/someuseful-mcp"
+      ],
+      "env": {
+        "SUSS_REPO_ROOT": "/absolute/path/to/SomeUsefulShellScripts"
+      }
+    }
+  }
+}
+```
+
+示例对话：
+
+```text
+Use the MCP tool `go_list_dep` from `someuseful-shell-scripts`
+to inspect packages ["fmt"] with includeStdlib=true and testImportDepth=0.
+```
+
+### OpenClaw
+
+OpenClaw 自身的 CLI fallback backend 不直接消费这个仓库的 MCP 配置；更实用的接法是：
+
+1. 先按上面的 Claude Code 示例把这个 MCP 注册到本机 `claude` CLI。
+2. 再让 OpenClaw 使用内置的 `claude-cli/...` backend。
+
+如果你的 OpenClaw Gateway 运行环境找不到 `claude`，可以在 OpenClaw 配置里显式指定命令路径：
+
+```json5
+{
+  agents: {
+    defaults: {
+      cliBackends: {
+        "claude-cli": {
+          command: "/opt/homebrew/bin/claude"
+        }
+      }
+    }
+  }
+}
+```
+
+然后用 `claude-cli/...` 模型发起请求：
+
+```bash
+openclaw agent \
+  --model claude-cli/opus-4.6 \
+  --message 'Use the configured MCP server `someuseful-shell-scripts` and call `go_list_dep` for packages ["fmt"].'
+```
+
+这里真正执行 MCP tool 的仍然是 `claude` CLI；OpenClaw 负责把会话路由到 `claude-cli` backend。
+
 ## 可选环境变量
 
 - `SUSS_REPO_ROOT`
@@ -57,4 +139,3 @@ go run ./cmd/someuseful-mcp
 - 当前先不引入 tasks、resources、prompts。
 - 当前先不做批量高风险操作，只暴露只读工具。
 - 当前先保留 Bash 作为执行层，后续如果某个工具复杂度上来，再换成 Go 实现。
-

--- a/mcp/cmd/someuseful-mcp/main.go
+++ b/mcp/cmd/someuseful-mcp/main.go
@@ -1,0 +1,639 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	serverName        = "someuseful-shell-scripts"
+	serverTitle       = "SomeUsefulShellScripts MCP"
+	serverVersion     = "0.1.0"
+	latestProtocolVer = "2025-11-25"
+)
+
+var supportedProtocolVersions = []string{
+	latestProtocolVer,
+	"2025-06-18",
+	"2025-03-26",
+	"2024-11-05",
+}
+
+type requestEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type responseEnvelope struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *rpcError   `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type toolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+type goListDepOptions struct {
+	Packages         []string
+	IncludeStdlib    bool
+	TestImportDepth  int
+	WorkingDirectory string
+}
+
+type scriptResult struct {
+	OK              bool     `json:"ok"`
+	Packages        []string `json:"packages"`
+	IncludeStdlib   bool     `json:"include_stdlib"`
+	TestImportDepth int      `json:"test_import_depth"`
+	Dependencies    []string `json:"dependencies"`
+}
+
+type toolStructuredResult struct {
+	OK              bool     `json:"ok"`
+	Packages        []string `json:"packages"`
+	IncludeStdlib   bool     `json:"includeStdlib"`
+	TestImportDepth int      `json:"testImportDepth"`
+	Dependencies    []string `json:"dependencies"`
+}
+
+type server struct {
+	out         *bufio.Writer
+	errOut      io.Writer
+	initialized bool
+}
+
+func main() {
+	srv := &server{
+		out:    bufio.NewWriter(os.Stdout),
+		errOut: os.Stderr,
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		response, ok := srv.handleMessage(line)
+		if !ok {
+			continue
+		}
+
+		if _, err := srv.out.Write(response); err != nil {
+			fmt.Fprintf(srv.errOut, "write response: %v\n", err)
+			os.Exit(1)
+		}
+		if err := srv.out.WriteByte('\n'); err != nil {
+			fmt.Fprintf(srv.errOut, "write newline: %v\n", err)
+			os.Exit(1)
+		}
+		if err := srv.out.Flush(); err != nil {
+			fmt.Fprintf(srv.errOut, "flush stdout: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(srv.errOut, "read stdin: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func (s *server) handleMessage(line []byte) ([]byte, bool) {
+	if bytes.HasPrefix(bytes.TrimSpace(line), []byte("[")) {
+		return s.handleBatch(line)
+	}
+	return s.handleSingle(line)
+}
+
+func (s *server) handleBatch(line []byte) ([]byte, bool) {
+	var rawBatch []json.RawMessage
+	if err := json.Unmarshal(line, &rawBatch); err != nil {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      nil,
+			Error:   &rpcError{Code: -32700, Message: "parse error", Data: err.Error()},
+		})
+	}
+
+	responses := make([]json.RawMessage, 0, len(rawBatch))
+	for _, raw := range rawBatch {
+		response, ok := s.handleSingle(raw)
+		if ok {
+			responses = append(responses, response)
+		}
+	}
+
+	if len(responses) == 0 {
+		return nil, false
+	}
+
+	encoded, err := json.Marshal(responses)
+	if err != nil {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      nil,
+			Error:   &rpcError{Code: -32603, Message: "internal error", Data: err.Error()},
+		})
+	}
+	return encoded, true
+}
+
+func (s *server) handleSingle(line []byte) ([]byte, bool) {
+	var req requestEnvelope
+	if err := json.Unmarshal(line, &req); err != nil {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      nil,
+			Error:   &rpcError{Code: -32700, Message: "parse error", Data: err.Error()},
+		})
+	}
+
+	if req.JSONRPC != "2.0" {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Error:   &rpcError{Code: -32600, Message: "invalid request", Data: "jsonrpc must be 2.0"},
+		})
+	}
+
+	if req.Method == "" {
+		return nil, false
+	}
+
+	if !s.initialized && req.Method != "initialize" && req.Method != "notifications/initialized" {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Error:   &rpcError{Code: -32002, Message: "server not initialized"},
+		})
+	}
+
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "notifications/initialized":
+		s.initialized = true
+		return nil, false
+	case "ping":
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result:  map[string]interface{}{},
+		})
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(req)
+	case "shutdown":
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result:  map[string]interface{}{},
+		})
+	default:
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Error:   &rpcError{Code: -32601, Message: "method not found", Data: req.Method},
+		})
+	}
+}
+
+func (s *server) handleInitialize(req requestEnvelope) ([]byte, bool) {
+	var params initializeParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32602, Message: "invalid initialize params", Data: err.Error()},
+			})
+		}
+	}
+
+	s.initialized = true
+
+	result := map[string]interface{}{
+		"protocolVersion": negotiateProtocolVersion(params.ProtocolVersion),
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{
+				"listChanged": false,
+			},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":        serverName,
+			"title":       serverTitle,
+			"version":     serverVersion,
+			"description": "Minimal stdio MCP server for curated local automation tools.",
+		},
+		"instructions": "Prefer the read-only tool go_list_dep for Go dependency inspection. High-risk shell utilities are intentionally not exposed yet.",
+	}
+
+	return marshalResponse(responseEnvelope{
+		JSONRPC: "2.0",
+		ID:      rawIDToValue(req.ID),
+		Result:  result,
+	})
+}
+
+func (s *server) handleToolsList(req requestEnvelope) ([]byte, bool) {
+	tool := map[string]interface{}{
+		"name":        "go_list_dep",
+		"title":       "List Go Package Dependencies",
+		"description": "Run the repository's go-list-dep CLI and return Go package dependencies as structured data.",
+		"inputSchema": map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"packages": map[string]interface{}{
+					"type":        "array",
+					"description": "Go packages or import paths to inspect. Defaults to ['.'].",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"includeStdlib": map[string]interface{}{
+					"type":        "boolean",
+					"description": "When true, keep standard library packages in the result.",
+				},
+				"testImportDepth": map[string]interface{}{
+					"type":        "integer",
+					"description": "How many recursive TestImports levels to follow. Defaults to 1.",
+				},
+				"workingDirectory": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional working directory for the underlying go list command.",
+				},
+			},
+		},
+		"outputSchema": map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"ok": map[string]interface{}{
+					"type": "boolean",
+				},
+				"packages": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"includeStdlib": map[string]interface{}{
+					"type": "boolean",
+				},
+				"testImportDepth": map[string]interface{}{
+					"type": "integer",
+				},
+				"dependencies": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			"required": []string{"ok", "packages", "includeStdlib", "testImportDepth", "dependencies"},
+		},
+		"annotations": map[string]interface{}{
+			"title":           "Go dependency list",
+			"readOnlyHint":    true,
+			"destructiveHint": false,
+			"idempotentHint":  true,
+			"openWorldHint":   false,
+		},
+	}
+
+	return marshalResponse(responseEnvelope{
+		JSONRPC: "2.0",
+		ID:      rawIDToValue(req.ID),
+		Result: map[string]interface{}{
+			"tools": []interface{}{tool},
+		},
+	})
+}
+
+func (s *server) handleToolsCall(req requestEnvelope) ([]byte, bool) {
+	var params toolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Error:   &rpcError{Code: -32602, Message: "invalid tool call params", Data: err.Error()},
+		})
+	}
+
+	switch params.Name {
+	case "go_list_dep":
+		result, err := runGoListDep(params.Arguments)
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Result: map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{
+							"type": "text",
+							"text": err.Error(),
+						},
+					},
+					"isError": true,
+				},
+			})
+		}
+
+		pretty, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32603, Message: "failed to encode tool result", Data: err.Error()},
+			})
+		}
+
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result: map[string]interface{}{
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "text",
+						"text": string(pretty),
+					},
+				},
+				"structuredContent": result,
+				"isError":           false,
+			},
+		})
+	default:
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Error:   &rpcError{Code: -32601, Message: "tool not found", Data: params.Name},
+		})
+	}
+}
+
+func runGoListDep(arguments map[string]interface{}) (toolStructuredResult, error) {
+	options, err := parseGoListDepOptions(arguments)
+	if err != nil {
+		return toolStructuredResult{}, err
+	}
+
+	scriptPath, err := resolveGoListDepScript()
+	if err != nil {
+		return toolStructuredResult{}, err
+	}
+
+	args := []string{scriptPath, "--json", "--test-import-depth", strconv.Itoa(options.TestImportDepth)}
+	if options.IncludeStdlib {
+		args = append(args, "--include-stdlib")
+	}
+	args = append(args, options.Packages...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", args...)
+	if options.WorkingDirectory != "" {
+		cmd.Dir = options.WorkingDirectory
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderrText := strings.TrimSpace(string(exitErr.Stderr))
+			if stderrText == "" {
+				stderrText = exitErr.Error()
+			}
+			return toolStructuredResult{}, fmt.Errorf("go_list_dep failed: %s", stderrText)
+		}
+		return toolStructuredResult{}, fmt.Errorf("go_list_dep execution failed: %w", err)
+	}
+
+	var parsed scriptResult
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return toolStructuredResult{}, fmt.Errorf("invalid JSON from go-list-dep script: %w", err)
+	}
+
+	return toolStructuredResult{
+		OK:              parsed.OK,
+		Packages:        parsed.Packages,
+		IncludeStdlib:   parsed.IncludeStdlib,
+		TestImportDepth: parsed.TestImportDepth,
+		Dependencies:    parsed.Dependencies,
+	}, nil
+}
+
+func parseGoListDepOptions(arguments map[string]interface{}) (goListDepOptions, error) {
+	options := goListDepOptions{
+		Packages:        []string{"."},
+		IncludeStdlib:   false,
+		TestImportDepth: 1,
+	}
+
+	if len(arguments) == 0 {
+		return options, nil
+	}
+
+	if value, ok := arguments["packages"]; ok {
+		packages, err := toStringSlice(value)
+		if err != nil {
+			return options, fmt.Errorf("packages must be a string or array of strings")
+		}
+		if len(packages) > 0 {
+			options.Packages = packages
+		}
+	}
+
+	if value, ok := firstValue(arguments, "includeStdlib", "include_stdlib"); ok {
+		booleanValue, ok := value.(bool)
+		if !ok {
+			return options, fmt.Errorf("includeStdlib must be a boolean")
+		}
+		options.IncludeStdlib = booleanValue
+	}
+
+	if value, ok := firstValue(arguments, "testImportDepth", "test_import_depth"); ok {
+		intValue, err := toInt(value)
+		if err != nil {
+			return options, fmt.Errorf("testImportDepth must be an integer")
+		}
+		options.TestImportDepth = intValue
+	}
+
+	if value, ok := firstValue(arguments, "workingDirectory", "working_directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("workingDirectory must be a string")
+		}
+		options.WorkingDirectory = stringValue
+	}
+
+	return options, nil
+}
+
+func toStringSlice(value interface{}) ([]string, error) {
+	switch typed := value.(type) {
+	case string:
+		if typed == "" {
+			return nil, nil
+		}
+		return []string{typed}, nil
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			stringItem, ok := item.(string)
+			if !ok {
+				return nil, errors.New("non-string value in array")
+			}
+			out = append(out, stringItem)
+		}
+		return out, nil
+	default:
+		return nil, errors.New("unsupported packages type")
+	}
+}
+
+func toInt(value interface{}) (int, error) {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), nil
+	case int:
+		return typed, nil
+	case string:
+		return strconv.Atoi(typed)
+	default:
+		return 0, errors.New("unsupported integer type")
+	}
+}
+
+func firstValue(arguments map[string]interface{}, keys ...string) (interface{}, bool) {
+	for _, key := range keys {
+		value, ok := arguments[key]
+		if ok {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func resolveGoListDepScript() (string, error) {
+	if explicitPath := os.Getenv("SUSS_GO_LIST_DEP_SCRIPT"); explicitPath != "" {
+		return ensureFile(explicitPath)
+	}
+
+	candidates := make([]string, 0, 6)
+
+	if repoRoot := os.Getenv("SUSS_REPO_ROOT"); repoRoot != "" {
+		candidates = append(candidates, filepath.Join(repoRoot, "shell", "go-list-dep.sh"))
+	}
+
+	if repoRoot, err := gitTopLevel(); err == nil && repoRoot != "" {
+		candidates = append(candidates, filepath.Join(repoRoot, "shell", "go-list-dep.sh"))
+	}
+
+	cwd, err := os.Getwd()
+	if err == nil {
+		candidates = append(candidates,
+			filepath.Join(cwd, "shell", "go-list-dep.sh"),
+			filepath.Join(cwd, "..", "shell", "go-list-dep.sh"),
+			filepath.Join(cwd, "..", "..", "shell", "go-list-dep.sh"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		resolved, err := ensureFile(candidate)
+		if err == nil {
+			return resolved, nil
+		}
+	}
+
+	return "", errors.New("unable to resolve shell/go-list-dep.sh; set SUSS_REPO_ROOT or SUSS_GO_LIST_DEP_SCRIPT")
+}
+
+func gitTopLevel() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func ensureFile(path string) (string, error) {
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory", resolved)
+	}
+	return resolved, nil
+}
+
+func negotiateProtocolVersion(requested string) string {
+	if slices.Contains(supportedProtocolVersions, requested) {
+		return requested
+	}
+	return latestProtocolVer
+}
+
+func rawIDToValue(id json.RawMessage) interface{} {
+	if len(id) == 0 {
+		return nil
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(id, &value); err != nil {
+		return nil
+	}
+	return value
+}
+
+func marshalResponse(response responseEnvelope) ([]byte, bool) {
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		fallback, _ := json.Marshal(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      nil,
+			Error:   &rpcError{Code: -32603, Message: "internal error", Data: err.Error()},
+		})
+		return fallback, true
+	}
+	return encoded, true
+}

--- a/mcp/cmd/someuseful-mcp/main.go
+++ b/mcp/cmd/someuseful-mcp/main.go
@@ -272,8 +272,6 @@ func (s *server) handleInitialize(req requestEnvelope) ([]byte, bool) {
 		}
 	}
 
-	s.initialized = true
-
 	result := map[string]interface{}{
 		"protocolVersion": negotiateProtocolVersion(params.ProtocolVersion),
 		"capabilities": map[string]interface{}{

--- a/mcp/cmd/someuseful-mcp/main.go
+++ b/mcp/cmd/someuseful-mcp/main.go
@@ -67,7 +67,15 @@ type goListDepOptions struct {
 	WorkingDirectory string
 }
 
-type scriptResult struct {
+type gitCountLineOptions struct {
+	BeginDate        string
+	EndDate          string
+	Directory        string
+	AuthorName       string
+	WorkingDirectory string
+}
+
+type goListDepScriptResult struct {
 	OK              bool     `json:"ok"`
 	Packages        []string `json:"packages"`
 	IncludeStdlib   bool     `json:"include_stdlib"`
@@ -75,12 +83,34 @@ type scriptResult struct {
 	Dependencies    []string `json:"dependencies"`
 }
 
-type toolStructuredResult struct {
+type goListDepStructuredResult struct {
 	OK              bool     `json:"ok"`
 	Packages        []string `json:"packages"`
 	IncludeStdlib   bool     `json:"includeStdlib"`
 	TestImportDepth int      `json:"testImportDepth"`
 	Dependencies    []string `json:"dependencies"`
+}
+
+type gitCountLineScriptResult struct {
+	OK           bool   `json:"ok"`
+	BeginDate    string `json:"begin_date"`
+	EndDate      string `json:"end_date"`
+	Directory    string `json:"directory"`
+	AuthorName   string `json:"author_name"`
+	AddedLines   int    `json:"added_lines"`
+	RemovedLines int    `json:"removed_lines"`
+	TotalLines   int    `json:"total_lines"`
+}
+
+type gitCountLineStructuredResult struct {
+	OK           bool   `json:"ok"`
+	BeginDate    string `json:"beginDate"`
+	EndDate      string `json:"endDate"`
+	Directory    string `json:"directory"`
+	AuthorName   string `json:"authorName"`
+	AddedLines   int    `json:"addedLines"`
+	RemovedLines int    `json:"removedLines"`
+	TotalLines   int    `json:"totalLines"`
 }
 
 type server struct {
@@ -257,7 +287,7 @@ func (s *server) handleInitialize(req requestEnvelope) ([]byte, bool) {
 			"version":     serverVersion,
 			"description": "Minimal stdio MCP server for curated local automation tools.",
 		},
-		"instructions": "Prefer the read-only tool go_list_dep for Go dependency inspection. High-risk shell utilities are intentionally not exposed yet.",
+		"instructions": "Prefer the read-only tools go_list_dep and git_count_line for structured repository inspection. High-risk shell utilities are intentionally not exposed yet.",
 	}
 
 	return marshalResponse(responseEnvelope{
@@ -268,68 +298,119 @@ func (s *server) handleInitialize(req requestEnvelope) ([]byte, bool) {
 }
 
 func (s *server) handleToolsList(req requestEnvelope) ([]byte, bool) {
-	tool := map[string]interface{}{
-		"name":        "go_list_dep",
-		"title":       "List Go Package Dependencies",
-		"description": "Run the repository's go-list-dep CLI and return Go package dependencies as structured data.",
-		"inputSchema": map[string]interface{}{
-			"type":                 "object",
-			"additionalProperties": false,
-			"properties": map[string]interface{}{
-				"packages": map[string]interface{}{
-					"type":        "array",
-					"description": "Go packages or import paths to inspect. Defaults to ['.'].",
-					"items": map[string]interface{}{
-						"type": "string",
+	tools := []interface{}{
+		map[string]interface{}{
+			"name":        "go_list_dep",
+			"title":       "List Go Package Dependencies",
+			"description": "Run the repository's go-list-dep CLI and return Go package dependencies as structured data.",
+			"inputSchema": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"packages": map[string]interface{}{
+						"type":        "array",
+						"description": "Go packages or import paths to inspect. Defaults to ['.'].",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
 					},
-				},
-				"includeStdlib": map[string]interface{}{
-					"type":        "boolean",
-					"description": "When true, keep standard library packages in the result.",
-				},
-				"testImportDepth": map[string]interface{}{
-					"type":        "integer",
-					"description": "How many recursive TestImports levels to follow. Defaults to 1.",
-				},
-				"workingDirectory": map[string]interface{}{
-					"type":        "string",
-					"description": "Optional working directory for the underlying go list command.",
-				},
-			},
-		},
-		"outputSchema": map[string]interface{}{
-			"type": "object",
-			"properties": map[string]interface{}{
-				"ok": map[string]interface{}{
-					"type": "boolean",
-				},
-				"packages": map[string]interface{}{
-					"type": "array",
-					"items": map[string]interface{}{
-						"type": "string",
+					"includeStdlib": map[string]interface{}{
+						"type":        "boolean",
+						"description": "When true, keep standard library packages in the result.",
 					},
-				},
-				"includeStdlib": map[string]interface{}{
-					"type": "boolean",
-				},
-				"testImportDepth": map[string]interface{}{
-					"type": "integer",
-				},
-				"dependencies": map[string]interface{}{
-					"type": "array",
-					"items": map[string]interface{}{
-						"type": "string",
+					"testImportDepth": map[string]interface{}{
+						"type":        "integer",
+						"description": "How many recursive TestImports levels to follow. Defaults to 1.",
+					},
+					"workingDirectory": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional working directory for the underlying go list command.",
 					},
 				},
 			},
-			"required": []string{"ok", "packages", "includeStdlib", "testImportDepth", "dependencies"},
+			"outputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ok": map[string]interface{}{"type": "boolean"},
+					"packages": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+					"includeStdlib": map[string]interface{}{"type": "boolean"},
+					"testImportDepth": map[string]interface{}{
+						"type": "integer",
+					},
+					"dependencies": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+				"required": []string{"ok", "packages", "includeStdlib", "testImportDepth", "dependencies"},
+			},
+			"annotations": map[string]interface{}{
+				"title":           "Go dependency list",
+				"readOnlyHint":    true,
+				"destructiveHint": false,
+				"idempotentHint":  true,
+				"openWorldHint":   false,
+			},
 		},
-		"annotations": map[string]interface{}{
-			"title":           "Go dependency list",
-			"readOnlyHint":    true,
-			"destructiveHint": false,
-			"idempotentHint":  true,
-			"openWorldHint":   false,
+		map[string]interface{}{
+			"name":        "git_count_line",
+			"title":       "Count Git Lines by Author",
+			"description": "Run the repository's git-count-line CLI and return added and removed line totals for an author within a date range.",
+			"inputSchema": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"beginDate": map[string]interface{}{
+						"type":        "string",
+						"description": "Inclusive begin date, for example 2024-01-01.",
+					},
+					"endDate": map[string]interface{}{
+						"type":        "string",
+						"description": "Inclusive end date, for example 2026-01-01.",
+					},
+					"directory": map[string]interface{}{
+						"type":        "string",
+						"description": "Repository directory to inspect. Defaults to the current directory.",
+					},
+					"authorName": map[string]interface{}{
+						"type":        "string",
+						"description": "Author name to match. Defaults to git config user.name.",
+					},
+					"workingDirectory": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional working directory for launching the underlying script.",
+					},
+				},
+				"required": []string{"beginDate", "endDate"},
+			},
+			"outputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ok":           map[string]interface{}{"type": "boolean"},
+					"beginDate":    map[string]interface{}{"type": "string"},
+					"endDate":      map[string]interface{}{"type": "string"},
+					"directory":    map[string]interface{}{"type": "string"},
+					"authorName":   map[string]interface{}{"type": "string"},
+					"addedLines":   map[string]interface{}{"type": "integer"},
+					"removedLines": map[string]interface{}{"type": "integer"},
+					"totalLines":   map[string]interface{}{"type": "integer"},
+				},
+				"required": []string{"ok", "beginDate", "endDate", "directory", "authorName", "addedLines", "removedLines", "totalLines"},
+			},
+			"annotations": map[string]interface{}{
+				"title":           "Git line count",
+				"readOnlyHint":    true,
+				"destructiveHint": false,
+				"idempotentHint":  true,
+				"openWorldHint":   false,
+			},
 		},
 	}
 
@@ -337,7 +418,7 @@ func (s *server) handleToolsList(req requestEnvelope) ([]byte, bool) {
 		JSONRPC: "2.0",
 		ID:      rawIDToValue(req.ID),
 		Result: map[string]interface{}{
-			"tools": []interface{}{tool},
+			"tools": tools,
 		},
 	})
 }
@@ -394,6 +475,47 @@ func (s *server) handleToolsCall(req requestEnvelope) ([]byte, bool) {
 				"isError":           false,
 			},
 		})
+	case "git_count_line":
+		result, err := runGitCountLine(params.Arguments)
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Result: map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{
+							"type": "text",
+							"text": err.Error(),
+						},
+					},
+					"isError": true,
+				},
+			})
+		}
+
+		pretty, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32603, Message: "failed to encode tool result", Data: err.Error()},
+			})
+		}
+
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result: map[string]interface{}{
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "text",
+						"text": string(pretty),
+					},
+				},
+				"structuredContent": result,
+				"isError":           false,
+			},
+		})
 	default:
 		return marshalResponse(responseEnvelope{
 			JSONRPC: "2.0",
@@ -403,15 +525,15 @@ func (s *server) handleToolsCall(req requestEnvelope) ([]byte, bool) {
 	}
 }
 
-func runGoListDep(arguments map[string]interface{}) (toolStructuredResult, error) {
+func runGoListDep(arguments map[string]interface{}) (goListDepStructuredResult, error) {
 	options, err := parseGoListDepOptions(arguments)
 	if err != nil {
-		return toolStructuredResult{}, err
+		return goListDepStructuredResult{}, err
 	}
 
-	scriptPath, err := resolveGoListDepScript()
+	scriptPath, err := resolveShellScript("SUSS_GO_LIST_DEP_SCRIPT", "go-list-dep.sh")
 	if err != nil {
-		return toolStructuredResult{}, err
+		return goListDepStructuredResult{}, err
 	}
 
 	args := []string{scriptPath, "--json", "--test-import-depth", strconv.Itoa(options.TestImportDepth)}
@@ -436,17 +558,17 @@ func runGoListDep(arguments map[string]interface{}) (toolStructuredResult, error
 			if stderrText == "" {
 				stderrText = exitErr.Error()
 			}
-			return toolStructuredResult{}, fmt.Errorf("go_list_dep failed: %s", stderrText)
+			return goListDepStructuredResult{}, fmt.Errorf("go_list_dep failed: %s", stderrText)
 		}
-		return toolStructuredResult{}, fmt.Errorf("go_list_dep execution failed: %w", err)
+		return goListDepStructuredResult{}, fmt.Errorf("go_list_dep execution failed: %w", err)
 	}
 
-	var parsed scriptResult
+	var parsed goListDepScriptResult
 	if err := json.Unmarshal(output, &parsed); err != nil {
-		return toolStructuredResult{}, fmt.Errorf("invalid JSON from go-list-dep script: %w", err)
+		return goListDepStructuredResult{}, fmt.Errorf("invalid JSON from go-list-dep script: %w", err)
 	}
 
-	return toolStructuredResult{
+	return goListDepStructuredResult{
 		OK:              parsed.OK,
 		Packages:        parsed.Packages,
 		IncludeStdlib:   parsed.IncludeStdlib,
@@ -503,6 +625,121 @@ func parseGoListDepOptions(arguments map[string]interface{}) (goListDepOptions, 
 	return options, nil
 }
 
+func runGitCountLine(arguments map[string]interface{}) (gitCountLineStructuredResult, error) {
+	options, err := parseGitCountLineOptions(arguments)
+	if err != nil {
+		return gitCountLineStructuredResult{}, err
+	}
+
+	scriptPath, err := resolveShellScript("SUSS_GIT_COUNT_LINE_SCRIPT", "git-count-line.sh")
+	if err != nil {
+		return gitCountLineStructuredResult{}, err
+	}
+
+	args := []string{
+		scriptPath,
+		"--json",
+		"--begin-date", options.BeginDate,
+		"--end-date", options.EndDate,
+		"--directory", options.Directory,
+	}
+	if options.AuthorName != "" {
+		args = append(args, "--author", options.AuthorName)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", args...)
+	if options.WorkingDirectory != "" {
+		cmd.Dir = options.WorkingDirectory
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderrText := strings.TrimSpace(string(exitErr.Stderr))
+			if stderrText == "" {
+				stderrText = exitErr.Error()
+			}
+			return gitCountLineStructuredResult{}, fmt.Errorf("git_count_line failed: %s", stderrText)
+		}
+		return gitCountLineStructuredResult{}, fmt.Errorf("git_count_line execution failed: %w", err)
+	}
+
+	var parsed gitCountLineScriptResult
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return gitCountLineStructuredResult{}, fmt.Errorf("invalid JSON from git-count-line script: %w", err)
+	}
+
+	return gitCountLineStructuredResult{
+		OK:           parsed.OK,
+		BeginDate:    parsed.BeginDate,
+		EndDate:      parsed.EndDate,
+		Directory:    parsed.Directory,
+		AuthorName:   parsed.AuthorName,
+		AddedLines:   parsed.AddedLines,
+		RemovedLines: parsed.RemovedLines,
+		TotalLines:   parsed.TotalLines,
+	}, nil
+}
+
+func parseGitCountLineOptions(arguments map[string]interface{}) (gitCountLineOptions, error) {
+	options := gitCountLineOptions{
+		Directory: ".",
+	}
+
+	if len(arguments) == 0 {
+		return options, fmt.Errorf("beginDate is required")
+	}
+
+	if value, ok := firstValue(arguments, "beginDate", "begin_date"); ok {
+		stringValue, ok := value.(string)
+		if !ok || stringValue == "" {
+			return options, fmt.Errorf("beginDate must be a non-empty string")
+		}
+		options.BeginDate = stringValue
+	}
+	if value, ok := firstValue(arguments, "endDate", "end_date"); ok {
+		stringValue, ok := value.(string)
+		if !ok || stringValue == "" {
+			return options, fmt.Errorf("endDate must be a non-empty string")
+		}
+		options.EndDate = stringValue
+	}
+	if value, ok := firstValue(arguments, "directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok || stringValue == "" {
+			return options, fmt.Errorf("directory must be a non-empty string")
+		}
+		options.Directory = stringValue
+	}
+	if value, ok := firstValue(arguments, "authorName", "author_name"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("authorName must be a string")
+		}
+		options.AuthorName = stringValue
+	}
+	if value, ok := firstValue(arguments, "workingDirectory", "working_directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("workingDirectory must be a string")
+		}
+		options.WorkingDirectory = stringValue
+	}
+
+	if options.BeginDate == "" {
+		return options, fmt.Errorf("beginDate is required")
+	}
+	if options.EndDate == "" {
+		return options, fmt.Errorf("endDate is required")
+	}
+
+	return options, nil
+}
+
 func toStringSlice(value interface{}) ([]string, error) {
 	switch typed := value.(type) {
 	case string:
@@ -548,27 +785,27 @@ func firstValue(arguments map[string]interface{}, keys ...string) (interface{}, 
 	return nil, false
 }
 
-func resolveGoListDepScript() (string, error) {
-	if explicitPath := os.Getenv("SUSS_GO_LIST_DEP_SCRIPT"); explicitPath != "" {
+func resolveShellScript(explicitEnvName, scriptName string) (string, error) {
+	if explicitPath := os.Getenv(explicitEnvName); explicitPath != "" {
 		return ensureFile(explicitPath)
 	}
 
 	candidates := make([]string, 0, 6)
 
 	if repoRoot := os.Getenv("SUSS_REPO_ROOT"); repoRoot != "" {
-		candidates = append(candidates, filepath.Join(repoRoot, "shell", "go-list-dep.sh"))
+		candidates = append(candidates, filepath.Join(repoRoot, "shell", scriptName))
 	}
 
 	if repoRoot, err := gitTopLevel(); err == nil && repoRoot != "" {
-		candidates = append(candidates, filepath.Join(repoRoot, "shell", "go-list-dep.sh"))
+		candidates = append(candidates, filepath.Join(repoRoot, "shell", scriptName))
 	}
 
 	cwd, err := os.Getwd()
 	if err == nil {
 		candidates = append(candidates,
-			filepath.Join(cwd, "shell", "go-list-dep.sh"),
-			filepath.Join(cwd, "..", "shell", "go-list-dep.sh"),
-			filepath.Join(cwd, "..", "..", "shell", "go-list-dep.sh"),
+			filepath.Join(cwd, "shell", scriptName),
+			filepath.Join(cwd, "..", "shell", scriptName),
+			filepath.Join(cwd, "..", "..", "shell", scriptName),
 		)
 	}
 
@@ -579,7 +816,7 @@ func resolveGoListDepScript() (string, error) {
 		}
 	}
 
-	return "", errors.New("unable to resolve shell/go-list-dep.sh; set SUSS_REPO_ROOT or SUSS_GO_LIST_DEP_SCRIPT")
+	return "", fmt.Errorf("unable to resolve shell/%s; set SUSS_REPO_ROOT or %s", scriptName, explicitEnvName)
 }
 
 func gitTopLevel() (string, error) {

--- a/mcp/cmd/someuseful-mcp/main_test.go
+++ b/mcp/cmd/someuseful-mcp/main_test.go
@@ -44,6 +44,52 @@ func TestParseGoListDepOptionsAliases(t *testing.T) {
 	}
 }
 
+func TestParseGitCountLineOptionsDefaults(t *testing.T) {
+	options, err := parseGitCountLineOptions(map[string]interface{}{
+		"beginDate": "2024-01-01",
+		"endDate":   "2024-12-31",
+	})
+	if err != nil {
+		t.Fatalf("parseGitCountLineOptions returned error: %v", err)
+	}
+
+	if options.BeginDate != "2024-01-01" || options.EndDate != "2024-12-31" {
+		t.Fatalf("unexpected date range: %#v", options)
+	}
+	if options.Directory != "." {
+		t.Fatalf("unexpected default directory: %s", options.Directory)
+	}
+	if options.AuthorName != "" {
+		t.Fatalf("expected empty default author name, got: %s", options.AuthorName)
+	}
+}
+
+func TestParseGitCountLineOptionsAliases(t *testing.T) {
+	options, err := parseGitCountLineOptions(map[string]interface{}{
+		"begin_date":        "2024-01-01",
+		"end_date":          "2024-12-31",
+		"directory":         "/tmp/repo",
+		"author_name":       "BillZong",
+		"working_directory": "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("parseGitCountLineOptions returned error: %v", err)
+	}
+
+	if options.BeginDate != "2024-01-01" || options.EndDate != "2024-12-31" {
+		t.Fatalf("unexpected date range: %#v", options)
+	}
+	if options.Directory != "/tmp/repo" {
+		t.Fatalf("unexpected directory: %s", options.Directory)
+	}
+	if options.AuthorName != "BillZong" {
+		t.Fatalf("unexpected author name: %s", options.AuthorName)
+	}
+	if options.WorkingDirectory != "/tmp" {
+		t.Fatalf("unexpected working directory: %s", options.WorkingDirectory)
+	}
+}
+
 func TestNegotiateProtocolVersion(t *testing.T) {
 	if got := negotiateProtocolVersion("2024-11-05"); got != "2024-11-05" {
 		t.Fatalf("expected requested supported protocol version, got %s", got)

--- a/mcp/cmd/someuseful-mcp/main_test.go
+++ b/mcp/cmd/someuseful-mcp/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestParseGoListDepOptionsDefaults(t *testing.T) {
+	options, err := parseGoListDepOptions(nil)
+	if err != nil {
+		t.Fatalf("parseGoListDepOptions returned error: %v", err)
+	}
+
+	if len(options.Packages) != 1 || options.Packages[0] != "." {
+		t.Fatalf("unexpected default packages: %#v", options.Packages)
+	}
+	if options.IncludeStdlib {
+		t.Fatalf("expected include stdlib to default to false")
+	}
+	if options.TestImportDepth != 1 {
+		t.Fatalf("unexpected default test import depth: %d", options.TestImportDepth)
+	}
+}
+
+func TestParseGoListDepOptionsAliases(t *testing.T) {
+	options, err := parseGoListDepOptions(map[string]interface{}{
+		"packages":          []interface{}{"fmt", "net/http"},
+		"include_stdlib":    true,
+		"test_import_depth": float64(0),
+		"working_directory": "/tmp/demo",
+	})
+	if err != nil {
+		t.Fatalf("parseGoListDepOptions returned error: %v", err)
+	}
+
+	if len(options.Packages) != 2 || options.Packages[0] != "fmt" || options.Packages[1] != "net/http" {
+		t.Fatalf("unexpected packages: %#v", options.Packages)
+	}
+	if !options.IncludeStdlib {
+		t.Fatalf("expected include stdlib to be true")
+	}
+	if options.TestImportDepth != 0 {
+		t.Fatalf("unexpected test import depth: %d", options.TestImportDepth)
+	}
+	if options.WorkingDirectory != "/tmp/demo" {
+		t.Fatalf("unexpected working directory: %s", options.WorkingDirectory)
+	}
+}
+
+func TestNegotiateProtocolVersion(t *testing.T) {
+	if got := negotiateProtocolVersion("2024-11-05"); got != "2024-11-05" {
+		t.Fatalf("expected requested supported protocol version, got %s", got)
+	}
+	if got := negotiateProtocolVersion("2099-01-01"); got != latestProtocolVer {
+		t.Fatalf("expected fallback to latest protocol version, got %s", got)
+	}
+}

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,0 +1,4 @@
+module github.com/BillZong/SomeUsefulShellScripts/mcp
+
+go 1.25.0
+

--- a/shell/git-count-line.sh
+++ b/shell/git-count-line.sh
@@ -1,26 +1,171 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-HELP="Usage: \n$0 {begin_date, eg:2023-05-09} {end_date, eg: 2024-05-09} [{count_directory}|"."] [{author_name}|{git config user name}]"
+PROGRAM_NAME=$(basename "$0")
 
-if [ "$#" -lt 2 ]; then
-	echo $HELP
-	exit -1
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME [options]
+       $PROGRAM_NAME <begin_date> <end_date> [directory] [author_name]
+
+Count added and removed lines in a git repository for a given author and date range.
+
+Options:
+  -h, --help                  Show this help message.
+  -j, --json                  Print a JSON document instead of plain text.
+  -b, --begin-date DATE       Inclusive begin date, for example 2024-01-01.
+  -e, --end-date DATE         Inclusive end date, for example 2026-01-01.
+  -d, --directory PATH        Repository directory. Defaults to current directory.
+  -a, --author NAME           Author name. Defaults to git config user.name.
+
+Examples:
+  $PROGRAM_NAME 2024-01-01 2026-01-01 .
+  $PROGRAM_NAME --begin-date 2024-01-01 --end-date 2026-01-01 --author "BillZong"
+  $PROGRAM_NAME --json -b 2024-01-01 -e 2026-01-01 -d .
+EOF
+}
+
+die() {
+    echo "[$PROGRAM_NAME] $*" >&2
+    exit 1
+}
+
+json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g'
+}
+
+JSON_OUTPUT=0
+BEGIN_DATE=""
+END_DATE=""
+DIRECTORY="."
+AUTHOR_NAME=""
+POSITIONAL=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -j | --json)
+            JSON_OUTPUT=1
+            shift
+            ;;
+        -b | --begin-date)
+            [ "$#" -ge 2 ] || die "missing value for --begin-date"
+            BEGIN_DATE=$2
+            shift 2
+            ;;
+        --begin-date=*)
+            BEGIN_DATE=${1#*=}
+            shift
+            ;;
+        -e | --end-date)
+            [ "$#" -ge 2 ] || die "missing value for --end-date"
+            END_DATE=$2
+            shift 2
+            ;;
+        --end-date=*)
+            END_DATE=${1#*=}
+            shift
+            ;;
+        -d | --directory)
+            [ "$#" -ge 2 ] || die "missing value for --directory"
+            DIRECTORY=$2
+            shift 2
+            ;;
+        --directory=*)
+            DIRECTORY=${1#*=}
+            shift
+            ;;
+        -a | --author)
+            [ "$#" -ge 2 ] || die "missing value for --author"
+            AUTHOR_NAME=$2
+            shift 2
+            ;;
+        --author=*)
+            AUTHOR_NAME=${1#*=}
+            shift
+            ;;
+        --)
+            shift
+            while [ "$#" -gt 0 ]; do
+                POSITIONAL+=("$1")
+                shift
+            done
+            break
+            ;;
+        -*)
+            die "unknown option: $1"
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$BEGIN_DATE" ] && [ "${#POSITIONAL[@]}" -ge 1 ]; then
+    BEGIN_DATE=${POSITIONAL[0]}
+fi
+if [ -z "$END_DATE" ] && [ "${#POSITIONAL[@]}" -ge 2 ]; then
+    END_DATE=${POSITIONAL[1]}
+fi
+if [ "$DIRECTORY" = "." ] && [ "${#POSITIONAL[@]}" -ge 3 ]; then
+    DIRECTORY=${POSITIONAL[2]}
+fi
+if [ -z "$AUTHOR_NAME" ] && [ "${#POSITIONAL[@]}" -ge 4 ]; then
+    AUTHOR_NAME=${POSITIONAL[3]}
 fi
 
-BEGIN=$1
-END=$2
-DIRECTORY=${3:-'.'}
-AUTHOR_NAME=$4
+[ -n "$BEGIN_DATE" ] || die "begin date is required"
+[ -n "$END_DATE" ] || die "end date is required"
+[ -d "$DIRECTORY" ] || die "directory does not exist: $DIRECTORY"
 
-if [ "$AUTHOR_NAME" == "" ]; then
-    AUTHOR_NAME=$(git config --get user.name)
+if ! git -C "$DIRECTORY" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    die "not a git repository: $DIRECTORY"
 fi
 
-git --git-dir=$DIRECTORY/.git log --author="$AUTHOR_NAME" \
---after="$BEGIN" --before="$END" \
---pretty=tformat: --numstat \
-| awk '{ add += $1 ; subs += $2 ; loc += $1 - $2 } \
-END { printf "added lines: %s\nremoved lines: \
-%s\ntotal lines: %s\n",add,subs,loc }'
+if [ -z "$AUTHOR_NAME" ]; then
+    AUTHOR_NAME=$(git -C "$DIRECTORY" config --get user.name || true)
+fi
+
+[ -n "$AUTHOR_NAME" ] || die "author name is required and could not be inferred from git config"
+
+stats=$(
+    git -C "$DIRECTORY" log --author="$AUTHOR_NAME" \
+        --after="$BEGIN_DATE" --before="$END_DATE" \
+        --pretty=tformat: --numstat \
+        | awk '
+            $1 ~ /^[0-9]+$/ { add += $1 }
+            $2 ~ /^[0-9]+$/ { subs += $2 }
+            END {
+                printf "%s\t%s\t%s\n", add + 0, subs + 0, (add - subs) + 0
+            }
+        '
+)
+
+added_lines=$(printf '%s' "$stats" | awk -F '\t' '{print $1}')
+removed_lines=$(printf '%s' "$stats" | awk -F '\t' '{print $2}')
+total_lines=$(printf '%s' "$stats" | awk -F '\t' '{print $3}')
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '{\n'
+    printf '  "ok": true,\n'
+    printf '  "begin_date": "%s",\n' "$(json_escape "$BEGIN_DATE")"
+    printf '  "end_date": "%s",\n' "$(json_escape "$END_DATE")"
+    printf '  "directory": "%s",\n' "$(json_escape "$DIRECTORY")"
+    printf '  "author_name": "%s",\n' "$(json_escape "$AUTHOR_NAME")"
+    printf '  "added_lines": %s,\n' "$added_lines"
+    printf '  "removed_lines": %s,\n' "$removed_lines"
+    printf '  "total_lines": %s\n' "$total_lines"
+    printf '}\n'
+    exit 0
+fi
+
+printf 'added lines: %s\n' "$added_lines"
+printf 'removed lines: %s\n' "$removed_lines"
+printf 'total lines: %s\n' "$total_lines"

--- a/shell/git-count-line.sh
+++ b/shell/git-count-line.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common-cli.sh
+source "$SCRIPT_DIR/lib/common-cli.sh"
+
 PROGRAM_NAME=$(basename "$0")
 
 usage() {
@@ -26,17 +30,6 @@ Examples:
 EOF
 }
 
-die() {
-    echo "[$PROGRAM_NAME] $*" >&2
-    exit 1
-}
-
-json_escape() {
-    printf '%s' "$1" | sed \
-        -e 's/\\/\\\\/g' \
-        -e 's/"/\\"/g'
-}
-
 JSON_OUTPUT=0
 BEGIN_DATE=""
 END_DATE=""
@@ -55,7 +48,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -b | --begin-date)
-            [ "$#" -ge 2 ] || die "missing value for --begin-date"
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --begin-date"
             BEGIN_DATE=$2
             shift 2
             ;;
@@ -64,7 +57,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -e | --end-date)
-            [ "$#" -ge 2 ] || die "missing value for --end-date"
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --end-date"
             END_DATE=$2
             shift 2
             ;;
@@ -73,7 +66,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -d | --directory)
-            [ "$#" -ge 2 ] || die "missing value for --directory"
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --directory"
             DIRECTORY=$2
             shift 2
             ;;
@@ -82,7 +75,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -a | --author)
-            [ "$#" -ge 2 ] || die "missing value for --author"
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --author"
             AUTHOR_NAME=$2
             shift 2
             ;;
@@ -99,7 +92,7 @@ while [ "$#" -gt 0 ]; do
             break
             ;;
         -*)
-            die "unknown option: $1"
+            suss_die "$PROGRAM_NAME" "unknown option: $1"
             ;;
         *)
             POSITIONAL+=("$1")
@@ -121,19 +114,19 @@ if [ -z "$AUTHOR_NAME" ] && [ "${#POSITIONAL[@]}" -ge 4 ]; then
     AUTHOR_NAME=${POSITIONAL[3]}
 fi
 
-[ -n "$BEGIN_DATE" ] || die "begin date is required"
-[ -n "$END_DATE" ] || die "end date is required"
-[ -d "$DIRECTORY" ] || die "directory does not exist: $DIRECTORY"
+[ -n "$BEGIN_DATE" ] || suss_die "$PROGRAM_NAME" "begin date is required"
+[ -n "$END_DATE" ] || suss_die "$PROGRAM_NAME" "end date is required"
+[ -d "$DIRECTORY" ] || suss_die "$PROGRAM_NAME" "directory does not exist: $DIRECTORY"
 
 if ! git -C "$DIRECTORY" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    die "not a git repository: $DIRECTORY"
+    suss_die "$PROGRAM_NAME" "not a git repository: $DIRECTORY"
 fi
 
 if [ -z "$AUTHOR_NAME" ]; then
     AUTHOR_NAME=$(git -C "$DIRECTORY" config --get user.name || true)
 fi
 
-[ -n "$AUTHOR_NAME" ] || die "author name is required and could not be inferred from git config"
+[ -n "$AUTHOR_NAME" ] || suss_die "$PROGRAM_NAME" "author name is required and could not be inferred from git config"
 
 stats=$(
     git -C "$DIRECTORY" log --author="$AUTHOR_NAME" \
@@ -155,10 +148,10 @@ total_lines=$(printf '%s' "$stats" | awk -F '\t' '{print $3}')
 if [ "$JSON_OUTPUT" -eq 1 ]; then
     printf '{\n'
     printf '  "ok": true,\n'
-    printf '  "begin_date": "%s",\n' "$(json_escape "$BEGIN_DATE")"
-    printf '  "end_date": "%s",\n' "$(json_escape "$END_DATE")"
-    printf '  "directory": "%s",\n' "$(json_escape "$DIRECTORY")"
-    printf '  "author_name": "%s",\n' "$(json_escape "$AUTHOR_NAME")"
+    printf '  "begin_date": "%s",\n' "$(suss_json_escape "$BEGIN_DATE")"
+    printf '  "end_date": "%s",\n' "$(suss_json_escape "$END_DATE")"
+    printf '  "directory": "%s",\n' "$(suss_json_escape "$DIRECTORY")"
+    printf '  "author_name": "%s",\n' "$(suss_json_escape "$AUTHOR_NAME")"
     printf '  "added_lines": %s,\n' "$added_lines"
     printf '  "removed_lines": %s,\n' "$removed_lines"
     printf '  "total_lines": %s\n' "$total_lines"

--- a/shell/go-list-dep.sh
+++ b/shell/go-list-dep.sh
@@ -1,33 +1,225 @@
 #!/usr/bin/env bash
-# Usage: lsdep [PACKAGE...]
-#
-# Example (list github.com/foo/bar and package dir deps [the . argument])
-# $ lsdep github.com/foo/bar .
-#
-# By default, this will list dependencies (imports), test imports, and test
-# dependencies (imports made by test imports).  You can recurse further by
-# setting TESTIMPORTS to an integer greater than one, or to skip test
-# dependencies, set TESTIMPORTS to 0 or a negative integer.
 
-: "${TESTIMPORTS:=1}"
+set -euo pipefail
 
-lsdep_impl__ () {
-    local txtestimps='{{range $v := .TestImports}}{{print . "\n"}}{{end}}'
-    local txdeps='{{range $v := .Deps}}{{print . "\n"}}{{end}}'
+PROGRAM_NAME=$(basename "$0")
+DEFAULT_TEST_IMPORT_DEPTH=${TESTIMPORTS:-1}
 
-    {
-        go list -f "${txtestimps}${txdeps}" "$@"
-        if [[ -n "${TESTIMPORTS}" ]] && [[ "${TESTIMPORTS:-1}" -gt 0 ]]
-        then
-            go list -f "${txtestimps}" "$@" |
-            sort | uniq |
-            comm -23 - <(go list std | sort) |
-                TESTIMPORTS=$((TESTIMPORTS - 1)) xargs bash -c 'lsdep_impl__ "$@"' "$0"
-        fi
-    } |
-    sort | uniq |
-    comm -23 - <(go list std | sort)
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME [options] [PACKAGE...]
+
+List Go package dependencies, optionally including transitive test-import
+dependencies up to a configurable depth.
+
+Options:
+  -h, --help                  Show this help message.
+  -j, --json                  Print a JSON document instead of plain text.
+      --include-stdlib        Keep Go standard library packages in output.
+      --test-import-depth N   Recursively follow TestImports to depth N.
+                              Defaults to TESTIMPORTS or 1.
+
+Examples:
+  $PROGRAM_NAME .
+  $PROGRAM_NAME --test-import-depth 0 ./...
+  $PROGRAM_NAME --json --include-stdlib fmt
+EOF
 }
-export -f lsdep_impl__
 
-lsdep_impl__ "$@"
+die() {
+    echo "[$PROGRAM_NAME] $*" >&2
+    exit 1
+}
+
+is_integer() {
+    case "$1" in
+        '' | -) return 1 ;;
+        -[0-9]* | [0-9]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g'
+}
+
+json_array_from_args() {
+    local first=1
+    local item escaped
+
+    printf '['
+    for item in "$@"; do
+        escaped=$(json_escape "$item")
+        if [ $first -eq 0 ]; then
+            printf ','
+        fi
+        printf '"%s"' "$escaped"
+        first=0
+    done
+    printf ']'
+}
+
+json_array_from_file() {
+    local file=$1
+    local first=1
+    local item escaped
+
+    printf '['
+    while IFS= read -r item; do
+        [ -n "$item" ] || continue
+        escaped=$(json_escape "$item")
+        if [ $first -eq 0 ]; then
+            printf ','
+        fi
+        printf '"%s"' "$escaped"
+        first=0
+    done < "$file"
+    printf ']'
+}
+
+filter_stdlib_file() {
+    local input_file=$1
+    local output_file=$2
+
+    if [ "$INCLUDE_STDLIB" -eq 1 ]; then
+        cp "$input_file" "$output_file"
+        return
+    fi
+
+    if [ ! -s "$input_file" ]; then
+        : > "$output_file"
+        return
+    fi
+
+    comm -23 "$input_file" "$STDLIB_FILE" > "$output_file" || true
+}
+
+collect_deps() {
+    local depth=$1
+    shift
+
+    local deps_file="$TMP_DIR/deps-${depth}-$$-${RANDOM}.txt"
+    local raw_test_imports_file="$TMP_DIR/test-imports-raw-${depth}-$$-${RANDOM}.txt"
+    local filtered_test_imports_file="$TMP_DIR/test-imports-filtered-${depth}-$$-${RANDOM}.txt"
+    local next_packages=()
+    local package_name
+
+    go list -f '{{range .Deps}}{{printf "%s\n" .}}{{end}}' "$@" \
+        | sed '/^$/d' \
+        | sort -u > "$deps_file"
+    cat "$deps_file"
+
+    if [ "$depth" -le 0 ]; then
+        return
+    fi
+
+    go list -f '{{range .TestImports}}{{printf "%s\n" .}}{{end}}' "$@" \
+        | sed '/^$/d' \
+        | sort -u > "$raw_test_imports_file"
+
+    filter_stdlib_file "$raw_test_imports_file" "$filtered_test_imports_file"
+
+    if [ ! -s "$filtered_test_imports_file" ]; then
+        return
+    fi
+
+    while IFS= read -r package_name; do
+        [ -n "$package_name" ] || continue
+        next_packages+=("$package_name")
+    done < "$filtered_test_imports_file"
+
+    if [ "${#next_packages[@]}" -gt 0 ]; then
+        collect_deps "$((depth - 1))" "${next_packages[@]}"
+    fi
+}
+
+JSON_OUTPUT=0
+INCLUDE_STDLIB=0
+TEST_IMPORT_DEPTH=$DEFAULT_TEST_IMPORT_DEPTH
+PACKAGES=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -j | --json)
+            JSON_OUTPUT=1
+            shift
+            ;;
+        --include-stdlib)
+            INCLUDE_STDLIB=1
+            shift
+            ;;
+        --test-import-depth)
+            [ "$#" -ge 2 ] || die "missing value for --test-import-depth"
+            TEST_IMPORT_DEPTH=$2
+            shift 2
+            ;;
+        --test-import-depth=*)
+            TEST_IMPORT_DEPTH=${1#*=}
+            shift
+            ;;
+        --)
+            shift
+            while [ "$#" -gt 0 ]; do
+                PACKAGES+=("$1")
+                shift
+            done
+            break
+            ;;
+        -*)
+            die "unknown option: $1"
+            ;;
+        *)
+            PACKAGES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! is_integer "$TEST_IMPORT_DEPTH"; then
+    die "--test-import-depth must be an integer"
+fi
+
+if [ "${#PACKAGES[@]}" -eq 0 ]; then
+    PACKAGES=(.)
+fi
+
+command -v go >/dev/null 2>&1 || die "go command not found"
+
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/go-list-dep.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+STDLIB_FILE="$TMP_DIR/stdlib.txt"
+RAW_RESULTS_FILE="$TMP_DIR/results-raw.txt"
+RESULTS_FILE="$TMP_DIR/results.txt"
+FILTERED_RESULTS_FILE="$TMP_DIR/results-filtered.txt"
+
+go list -e -f '{{if .Standard}}{{.ImportPath}}{{end}}' std | sed '/^$/d' | sort -u > "$STDLIB_FILE"
+collect_deps "$TEST_IMPORT_DEPTH" "${PACKAGES[@]}" | sed '/^$/d' | sort -u > "$RAW_RESULTS_FILE"
+filter_stdlib_file "$RAW_RESULTS_FILE" "$FILTERED_RESULTS_FILE"
+mv "$FILTERED_RESULTS_FILE" "$RESULTS_FILE"
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '{\n'
+    printf '  "ok": true,\n'
+    printf '  "packages": '
+    json_array_from_args "${PACKAGES[@]}"
+    printf ',\n'
+    if [ "$INCLUDE_STDLIB" -eq 1 ]; then
+        printf '  "include_stdlib": true,\n'
+    else
+        printf '  "include_stdlib": false,\n'
+    fi
+    printf '  "test_import_depth": %s,\n' "$TEST_IMPORT_DEPTH"
+    printf '  "dependencies": '
+    json_array_from_file "$RESULTS_FILE"
+    printf '\n}\n'
+    exit 0
+fi
+
+cat "$RESULTS_FILE"

--- a/shell/go-list-dep.sh
+++ b/shell/go-list-dep.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common-cli.sh
+source "$SCRIPT_DIR/lib/common-cli.sh"
+
 PROGRAM_NAME=$(basename "$0")
 DEFAULT_TEST_IMPORT_DEPTH=${TESTIMPORTS:-1}
 
@@ -26,32 +30,13 @@ Examples:
 EOF
 }
 
-die() {
-    echo "[$PROGRAM_NAME] $*" >&2
-    exit 1
-}
-
-is_integer() {
-    case "$1" in
-        '' | -) return 1 ;;
-        -[0-9]* | [0-9]*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-json_escape() {
-    printf '%s' "$1" | sed \
-        -e 's/\\/\\\\/g' \
-        -e 's/"/\\"/g'
-}
-
 json_array_from_args() {
     local first=1
     local item escaped
 
     printf '['
     for item in "$@"; do
-        escaped=$(json_escape "$item")
+        escaped=$(suss_json_escape "$item")
         if [ $first -eq 0 ]; then
             printf ','
         fi
@@ -69,7 +54,7 @@ json_array_from_file() {
     printf '['
     while IFS= read -r item; do
         [ -n "$item" ] || continue
-        escaped=$(json_escape "$item")
+        escaped=$(suss_json_escape "$item")
         if [ $first -eq 0 ]; then
             printf ','
         fi
@@ -155,7 +140,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         --test-import-depth)
-            [ "$#" -ge 2 ] || die "missing value for --test-import-depth"
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --test-import-depth"
             TEST_IMPORT_DEPTH=$2
             shift 2
             ;;
@@ -172,7 +157,7 @@ while [ "$#" -gt 0 ]; do
             break
             ;;
         -*)
-            die "unknown option: $1"
+            suss_die "$PROGRAM_NAME" "unknown option: $1"
             ;;
         *)
             PACKAGES+=("$1")
@@ -181,15 +166,15 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-if ! is_integer "$TEST_IMPORT_DEPTH"; then
-    die "--test-import-depth must be an integer"
+if ! suss_is_integer "$TEST_IMPORT_DEPTH"; then
+    suss_die "$PROGRAM_NAME" "--test-import-depth must be an integer"
 fi
 
 if [ "${#PACKAGES[@]}" -eq 0 ]; then
     PACKAGES=(.)
 fi
 
-command -v go >/dev/null 2>&1 || die "go command not found"
+suss_require_command "go" "$PROGRAM_NAME"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/go-list-dep.XXXXXX")
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/shell/lib/common-cli.sh
+++ b/shell/lib/common-cli.sh
@@ -19,11 +19,7 @@ suss_require_command() {
 }
 
 suss_is_integer() {
-    case "$1" in
-        '' | -) return 1 ;;
-        -[0-9]* | [0-9]*) return 0 ;;
-        *) return 1 ;;
-    esac
+    [[ "$1" =~ ^-?[0-9]+$ ]]
 }
 
 suss_json_escape() {

--- a/shell/lib/common-cli.sh
+++ b/shell/lib/common-cli.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+if [ -n "${SUSS_COMMON_CLI_INCLUDED:-}" ]; then
+    return 0
+fi
+SUSS_COMMON_CLI_INCLUDED=1
+
+suss_die() {
+    local program_name=$1
+    shift
+    echo "[$program_name] $*" >&2
+    exit 1
+}
+
+suss_require_command() {
+    local command_name=$1
+    local program_name=$2
+    command -v "$command_name" >/dev/null 2>&1 || suss_die "$program_name" "$command_name command not found"
+}
+
+suss_is_integer() {
+    case "$1" in
+        '' | -) return 1 ;;
+        -[0-9]* | [0-9]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+suss_json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g'
+}

--- a/shell/lib/common-cli.sh
+++ b/shell/lib/common-cli.sh
@@ -27,7 +27,13 @@ suss_is_integer() {
 }
 
 suss_json_escape() {
-    printf '%s' "$1" | sed \
-        -e 's/\\/\\\\/g' \
-        -e 's/"/\\"/g'
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\b'/\\b}"
+    s="${s//$'\f'/\\f}"
+    printf '%s' "$s"
 }


### PR DESCRIPTION
## Summary
- add script inventory and migration planning docs
- stabilize `shell/go-list-dep.sh` as a first structured CLI
- add a minimal stdio MCP server under `mcp/` and expose `go_list_dep`

## Validation
- `bash -n shell/go-list-dep.sh`
- `bash shell/go-list-dep.sh --help`
- `bash shell/go-list-dep.sh --json --include-stdlib --test-import-depth 0 fmt`
- `cd mcp && env GOCACHE=/tmp/go-cache GOTMPDIR=/tmp/go-tmp go test ./...`
- smoke test `initialize`, `tools/list`, and `tools/call` for `go_list_dep`