### PR TITLE
Phase 2: add read-only docker/git/process tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Some utils using shell/python/perl scripts.
 - `docs/`: inventory and migration planning
 - `archive/`: planned archive area for deprecated scripts
 - `mcp/`: minimal MCP server skeleton for agent-facing tools
+- `shell/lib/`: shared Bash helpers for stabilized CLIs

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,7 +7,7 @@
 - `go_list_dep`
 - `git_count_line`
 - `docker_show_images_arch`
-- `git_status_subdir`
+- `git_status_subdirs`
 - `watch_program_memory`
 
 ## 特点
@@ -190,7 +190,7 @@ openclaw agent \
 - `images[].os`
 - `images[].variant`
 
-## Tool: `git_status_subdir`
+## Tool: `git_status_subdirs`
 
 输入参数：
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,10 +2,13 @@
 
 这是当前仓库的最小 MCP 骨架，目标是先把低风险、结构化、可组合的能力挂出来，再逐步扩展更多工具。
 
-当前暴露两个 tool：
+当前暴露五个 tool：
 
 - `go_list_dep`
 - `git_count_line`
+- `docker_show_images_arch`
+- `git_status_subdir`
+- `watch_program_memory`
 
 ## 特点
 
@@ -110,6 +113,12 @@ openclaw agent \
   - 显式指定 `go-list-dep` 脚本路径。
 - `SUSS_GIT_COUNT_LINE_SCRIPT`
   - 显式指定 `git-count-line.sh` 脚本路径。
+- `SUSS_DOCKER_SHOW_IMAGES_ARCH_SCRIPT`
+  - 显式指定 `docker-show-images-arch.sh` 脚本路径。
+- `SUSS_GIT_STATUS_SUBDIR_SCRIPT`
+  - 显式指定 `git-status-subdir.sh` 脚本路径。
+- `SUSS_WATCH_PROGRAM_MEMORY_SCRIPT`
+  - 显式指定 `watch-prog-memory.sh` 脚本路径。
 
 如果两者都不传，服务会优先尝试：
 
@@ -162,6 +171,73 @@ openclaw agent \
 - `addedLines`
 - `removedLines`
 - `totalLines`
+
+## Tool: `docker_show_images_arch`
+
+输入参数：
+
+- `images`
+  - `string[]`，可选，默认扫描本机全部本地镜像
+- `workingDirectory`
+  - `string`，可选，用于指定底层脚本的启动目录
+
+输出：
+
+- `ok`
+- `images[].id`
+- `images[].repoTags`
+- `images[].architecture`
+- `images[].os`
+- `images[].variant`
+
+## Tool: `git_status_subdir`
+
+输入参数：
+
+- `directory`
+  - `string`，可选，默认 `"."`
+- `depth`
+  - `integer`，可选，默认 `2`
+- `workingDirectory`
+  - `string`，可选，用于指定底层脚本的启动目录
+
+输出：
+
+- `ok`
+- `directory`
+- `depth`
+- `repositories[].path`
+- `repositories[].relativePath`
+- `repositories[].branch`
+- `repositories[].upstream`
+- `repositories[].ahead`
+- `repositories[].behind`
+- `repositories[].stagedCount`
+- `repositories[].unstagedCount`
+- `repositories[].untrackedCount`
+- `repositories[].conflictedCount`
+- `repositories[].clean`
+
+## Tool: `watch_program_memory`
+
+输入参数：
+
+- `program`
+  - `string`，必填，进程名或命令行匹配片段
+- `workingDirectory`
+  - `string`，可选，用于指定底层脚本的启动目录
+
+输出：
+
+- `ok`
+- `timestamp`
+- `program`
+- `matchCount`
+- `totalRssKb`
+- `processes[].pid`
+- `processes[].rssKb`
+- `processes[].command`
+- `processes[].args`
 
 ## 设计取舍
 

--- a/mcp/cmd/someuseful-mcp/git_status_subdir_script_test.go
+++ b/mcp/cmd/someuseful-mcp/git_status_subdir_script_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+type gitStatusSubdirScriptTestRepository struct {
+	Path string `json:"path"`
+}
+
+type gitStatusSubdirScriptTestResult struct {
+	OK           bool                                  `json:"ok"`
+	Directory    string                                `json:"directory"`
+	Depth        int                                   `json:"depth"`
+	Repositories []gitStatusSubdirScriptTestRepository `json:"repositories"`
+}
+
+func repoRootForScriptTests(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+
+	root := filepath.Clean(filepath.Join(cwd, "..", "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "shell", "git-status-subdir.sh")); err != nil {
+		t.Fatalf("locate git-status-subdir.sh: %v", err)
+	}
+
+	return root
+}
+
+func runCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, string(output))
+	}
+
+	return string(output)
+}
+
+func runGitStatusSubdirScript(t *testing.T, directory string, depth int) gitStatusSubdirScriptTestResult {
+	t.Helper()
+
+	scriptPath := filepath.Join(repoRootForScriptTests(t), "shell", "git-status-subdir.sh")
+	cmd := exec.Command("bash", scriptPath, "--json", "--directory", directory, "--depth", strconv.Itoa(depth))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git-status-subdir.sh failed: %v\n%s", err, string(output))
+	}
+
+	var result gitStatusSubdirScriptTestResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode script output: %v\n%s", err, string(output))
+	}
+
+	return result
+}
+
+func commitFixtureFile(t *testing.T, repoDir string, filename string, content string) {
+	t.Helper()
+
+	runCommand(t, repoDir, "git", "config", "user.name", "tester")
+	runCommand(t, repoDir, "git", "config", "user.email", "tester@example.com")
+
+	if err := os.WriteFile(filepath.Join(repoDir, filename), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture file: %v", err)
+	}
+
+	runCommand(t, repoDir, "git", "add", filename)
+	runCommand(t, repoDir, "git", "-c", "commit.gpgsign=false", "commit", "-m", "init")
+}
+
+func TestGitStatusSubdirScriptFindsWorktreeGitFile(t *testing.T) {
+	tempDir := t.TempDir()
+	rootDir := filepath.Join(tempDir, "root")
+	baseRepoDir := filepath.Join(rootDir, "base")
+	worktreeDir := filepath.Join(rootDir, "wt")
+
+	if err := os.MkdirAll(baseRepoDir, 0o755); err != nil {
+		t.Fatalf("mkdir base repo dir: %v", err)
+	}
+
+	runCommand(t, baseRepoDir, "git", "init")
+	commitFixtureFile(t, baseRepoDir, "file.txt", "base repo\n")
+	runCommand(t, baseRepoDir, "git", "worktree", "add", worktreeDir, "-b", "feature")
+
+	result := runGitStatusSubdirScript(t, rootDir, 1)
+	if len(result.Repositories) != 2 {
+		t.Fatalf("expected two repositories, got %#v", result.Repositories)
+	}
+
+	paths := map[string]bool{}
+	for _, repository := range result.Repositories {
+		paths[repository.Path] = true
+	}
+
+	if !paths[baseRepoDir] {
+		t.Fatalf("base repository missing from result: %#v", result.Repositories)
+	}
+	if !paths[worktreeDir] {
+		t.Fatalf("worktree repository missing from result: %#v", result.Repositories)
+	}
+}

--- a/mcp/cmd/someuseful-mcp/main.go
+++ b/mcp/cmd/someuseful-mcp/main.go
@@ -575,7 +575,7 @@ func (s *server) handleToolsList(req requestEnvelope) ([]byte, bool) {
 			},
 		},
 		map[string]interface{}{
-			"name":        "git_status_subdir",
+			"name":        "git_status_subdirs",
 			"title":       "Scan Git Repositories Under a Directory",
 			"description": "Run the repository's git-status-subdir CLI and summarize branch and working tree state for nested repositories.",
 			"inputSchema": map[string]interface{}{
@@ -821,7 +821,7 @@ func (s *server) handleToolsCall(req requestEnvelope) ([]byte, bool) {
 				"isError":           false,
 			},
 		})
-	case "git_status_subdir":
+	case "git_status_subdirs":
 		result, err := runGitStatusSubdir(params.Arguments)
 		if err != nil {
 			return marshalResponse(responseEnvelope{
@@ -1220,9 +1220,9 @@ func runGitStatusSubdir(arguments map[string]interface{}) (gitStatusSubdirStruct
 			if stderrText == "" {
 				stderrText = exitErr.Error()
 			}
-			return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdir failed: %s", stderrText)
+			return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdirs failed: %s", stderrText)
 		}
-		return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdir execution failed: %w", err)
+		return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdirs execution failed: %w", err)
 	}
 
 	var parsed gitStatusSubdirScriptResult

--- a/mcp/cmd/someuseful-mcp/main.go
+++ b/mcp/cmd/someuseful-mcp/main.go
@@ -75,6 +75,22 @@ type gitCountLineOptions struct {
 	WorkingDirectory string
 }
 
+type dockerShowImagesArchOptions struct {
+	Images           []string
+	WorkingDirectory string
+}
+
+type gitStatusSubdirOptions struct {
+	Directory        string
+	Depth            int
+	WorkingDirectory string
+}
+
+type watchProgramMemoryOptions struct {
+	Program          string
+	WorkingDirectory string
+}
+
 type goListDepScriptResult struct {
 	OK              bool     `json:"ok"`
 	Packages        []string `json:"packages"`
@@ -111,6 +127,106 @@ type gitCountLineStructuredResult struct {
 	AddedLines   int    `json:"addedLines"`
 	RemovedLines int    `json:"removedLines"`
 	TotalLines   int    `json:"totalLines"`
+}
+
+type dockerShowImagesArchScriptImage struct {
+	ID           string   `json:"id"`
+	RepoTags     []string `json:"repo_tags"`
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	Variant      string   `json:"variant"`
+}
+
+type dockerShowImagesArchScriptResult struct {
+	OK     bool                              `json:"ok"`
+	Images []dockerShowImagesArchScriptImage `json:"images"`
+}
+
+type dockerShowImagesArchStructuredImage struct {
+	ID           string   `json:"id"`
+	RepoTags     []string `json:"repoTags"`
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	Variant      string   `json:"variant"`
+}
+
+type dockerShowImagesArchStructuredResult struct {
+	OK     bool                                  `json:"ok"`
+	Images []dockerShowImagesArchStructuredImage `json:"images"`
+}
+
+type gitStatusSubdirScriptRepository struct {
+	Path            string `json:"path"`
+	RelativePath    string `json:"relative_path"`
+	Branch          string `json:"branch"`
+	Upstream        string `json:"upstream"`
+	Ahead           int    `json:"ahead"`
+	Behind          int    `json:"behind"`
+	StagedCount     int    `json:"staged_count"`
+	UnstagedCount   int    `json:"unstaged_count"`
+	UntrackedCount  int    `json:"untracked_count"`
+	ConflictedCount int    `json:"conflicted_count"`
+	Clean           bool   `json:"clean"`
+}
+
+type gitStatusSubdirScriptResult struct {
+	OK           bool                              `json:"ok"`
+	Directory    string                            `json:"directory"`
+	Depth        int                               `json:"depth"`
+	Repositories []gitStatusSubdirScriptRepository `json:"repositories"`
+}
+
+type gitStatusSubdirStructuredRepository struct {
+	Path            string `json:"path"`
+	RelativePath    string `json:"relativePath"`
+	Branch          string `json:"branch"`
+	Upstream        string `json:"upstream"`
+	Ahead           int    `json:"ahead"`
+	Behind          int    `json:"behind"`
+	StagedCount     int    `json:"stagedCount"`
+	UnstagedCount   int    `json:"unstagedCount"`
+	UntrackedCount  int    `json:"untrackedCount"`
+	ConflictedCount int    `json:"conflictedCount"`
+	Clean           bool   `json:"clean"`
+}
+
+type gitStatusSubdirStructuredResult struct {
+	OK           bool                                  `json:"ok"`
+	Directory    string                                `json:"directory"`
+	Depth        int                                   `json:"depth"`
+	Repositories []gitStatusSubdirStructuredRepository `json:"repositories"`
+}
+
+type watchProgramMemoryScriptProcess struct {
+	PID     int    `json:"pid"`
+	RSSKB   int    `json:"rss_kb"`
+	Command string `json:"command"`
+	Args    string `json:"args"`
+}
+
+type watchProgramMemoryScriptResult struct {
+	OK         bool                              `json:"ok"`
+	Timestamp  string                            `json:"timestamp"`
+	Program    string                            `json:"program"`
+	MatchCount int                               `json:"match_count"`
+	TotalRSSKB int                               `json:"total_rss_kb"`
+	Processes  []watchProgramMemoryScriptProcess `json:"processes"`
+}
+
+type watchProgramMemoryStructuredProcess struct {
+	PID     int    `json:"pid"`
+	RSSKB   int    `json:"rssKb"`
+	Command string `json:"command"`
+	Args    string `json:"args"`
+}
+
+type watchProgramMemoryStructuredResult struct {
+	OK         bool                                  `json:"ok"`
+	Timestamp  string                                `json:"timestamp"`
+	Program    string                                `json:"program"`
+	MatchCount int                                   `json:"matchCount"`
+	TotalRSSKB int                                   `json:"totalRssKb"`
+	Processes  []watchProgramMemoryStructuredProcess `json:"processes"`
 }
 
 type server struct {
@@ -285,7 +401,7 @@ func (s *server) handleInitialize(req requestEnvelope) ([]byte, bool) {
 			"version":     serverVersion,
 			"description": "Minimal stdio MCP server for curated local automation tools.",
 		},
-		"instructions": "Prefer the read-only tools go_list_dep and git_count_line for structured repository inspection. High-risk shell utilities are intentionally not exposed yet.",
+		"instructions": "Prefer the read-only tools for dependency inspection, git analytics, docker image metadata, multi-repo status scans, and process memory snapshots. High-risk shell utilities are intentionally not exposed.",
 	}
 
 	return marshalResponse(responseEnvelope{
@@ -410,6 +526,164 @@ func (s *server) handleToolsList(req requestEnvelope) ([]byte, bool) {
 				"openWorldHint":   false,
 			},
 		},
+		map[string]interface{}{
+			"name":        "docker_show_images_arch",
+			"title":       "Show Docker Image Architectures",
+			"description": "Run the repository's docker-show-images-arch CLI and return image architecture details as structured data.",
+			"inputSchema": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"images": map[string]interface{}{
+						"type":        "array",
+						"description": "Optional image references to inspect. Defaults to all local images.",
+						"items":       map[string]interface{}{"type": "string"},
+					},
+					"workingDirectory": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional working directory for launching the underlying script.",
+					},
+				},
+			},
+			"outputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ok": map[string]interface{}{"type": "boolean"},
+					"images": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"id":           map[string]interface{}{"type": "string"},
+								"repoTags":     map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+								"architecture": map[string]interface{}{"type": "string"},
+								"os":           map[string]interface{}{"type": "string"},
+								"variant":      map[string]interface{}{"type": "string"},
+							},
+							"required": []string{"id", "repoTags", "architecture", "os", "variant"},
+						},
+					},
+				},
+				"required": []string{"ok", "images"},
+			},
+			"annotations": map[string]interface{}{
+				"title":           "Docker image architectures",
+				"readOnlyHint":    true,
+				"destructiveHint": false,
+				"idempotentHint":  true,
+				"openWorldHint":   false,
+			},
+		},
+		map[string]interface{}{
+			"name":        "git_status_subdir",
+			"title":       "Scan Git Repositories Under a Directory",
+			"description": "Run the repository's git-status-subdir CLI and summarize branch and working tree state for nested repositories.",
+			"inputSchema": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"directory": map[string]interface{}{
+						"type":        "string",
+						"description": "Root directory to scan. Defaults to the current directory.",
+					},
+					"depth": map[string]interface{}{
+						"type":        "integer",
+						"description": "Max directory depth to scan for nested repositories. Defaults to 2.",
+					},
+					"workingDirectory": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional working directory for launching the underlying script.",
+					},
+				},
+			},
+			"outputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ok":        map[string]interface{}{"type": "boolean"},
+					"directory": map[string]interface{}{"type": "string"},
+					"depth":     map[string]interface{}{"type": "integer"},
+					"repositories": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"path":            map[string]interface{}{"type": "string"},
+								"relativePath":    map[string]interface{}{"type": "string"},
+								"branch":          map[string]interface{}{"type": "string"},
+								"upstream":        map[string]interface{}{"type": "string"},
+								"ahead":           map[string]interface{}{"type": "integer"},
+								"behind":          map[string]interface{}{"type": "integer"},
+								"stagedCount":     map[string]interface{}{"type": "integer"},
+								"unstagedCount":   map[string]interface{}{"type": "integer"},
+								"untrackedCount":  map[string]interface{}{"type": "integer"},
+								"conflictedCount": map[string]interface{}{"type": "integer"},
+								"clean":           map[string]interface{}{"type": "boolean"},
+							},
+							"required": []string{"path", "relativePath", "branch", "upstream", "ahead", "behind", "stagedCount", "unstagedCount", "untrackedCount", "conflictedCount", "clean"},
+						},
+					},
+				},
+				"required": []string{"ok", "directory", "depth", "repositories"},
+			},
+			"annotations": map[string]interface{}{
+				"title":           "Git repo status scan",
+				"readOnlyHint":    true,
+				"destructiveHint": false,
+				"idempotentHint":  true,
+				"openWorldHint":   false,
+			},
+		},
+		map[string]interface{}{
+			"name":        "watch_program_memory",
+			"title":       "Sample Program Memory",
+			"description": "Run the repository's watch-prog-memory CLI and return RSS memory totals for matching processes.",
+			"inputSchema": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"program": map[string]interface{}{
+						"type":        "string",
+						"description": "Program name or substring pattern to match.",
+					},
+					"workingDirectory": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional working directory for launching the underlying script.",
+					},
+				},
+				"required": []string{"program"},
+			},
+			"outputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ok":         map[string]interface{}{"type": "boolean"},
+					"timestamp":  map[string]interface{}{"type": "string"},
+					"program":    map[string]interface{}{"type": "string"},
+					"matchCount": map[string]interface{}{"type": "integer"},
+					"totalRssKb": map[string]interface{}{"type": "integer"},
+					"processes": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"pid":     map[string]interface{}{"type": "integer"},
+								"rssKb":   map[string]interface{}{"type": "integer"},
+								"command": map[string]interface{}{"type": "string"},
+								"args":    map[string]interface{}{"type": "string"},
+							},
+							"required": []string{"pid", "rssKb", "command", "args"},
+						},
+					},
+				},
+				"required": []string{"ok", "timestamp", "program", "matchCount", "totalRssKb", "processes"},
+			},
+			"annotations": map[string]interface{}{
+				"title":           "Program memory sample",
+				"readOnlyHint":    true,
+				"destructiveHint": false,
+				"idempotentHint":  true,
+				"openWorldHint":   true,
+			},
+		},
 	}
 
 	return marshalResponse(responseEnvelope{
@@ -510,6 +784,105 @@ func (s *server) handleToolsCall(req requestEnvelope) ([]byte, bool) {
 						"text": string(pretty),
 					},
 				},
+				"structuredContent": result,
+				"isError":           false,
+			},
+		})
+	case "docker_show_images_arch":
+		result, err := runDockerShowImagesArch(params.Arguments)
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Result: map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{"type": "text", "text": err.Error()},
+					},
+					"isError": true,
+				},
+			})
+		}
+
+		pretty, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32603, Message: "failed to encode tool result", Data: err.Error()},
+			})
+		}
+
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result: map[string]interface{}{
+				"content":           []interface{}{map[string]interface{}{"type": "text", "text": string(pretty)}},
+				"structuredContent": result,
+				"isError":           false,
+			},
+		})
+	case "git_status_subdir":
+		result, err := runGitStatusSubdir(params.Arguments)
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Result: map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{"type": "text", "text": err.Error()},
+					},
+					"isError": true,
+				},
+			})
+		}
+
+		pretty, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32603, Message: "failed to encode tool result", Data: err.Error()},
+			})
+		}
+
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result: map[string]interface{}{
+				"content":           []interface{}{map[string]interface{}{"type": "text", "text": string(pretty)}},
+				"structuredContent": result,
+				"isError":           false,
+			},
+		})
+	case "watch_program_memory":
+		result, err := runWatchProgramMemory(params.Arguments)
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Result: map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{"type": "text", "text": err.Error()},
+					},
+					"isError": true,
+				},
+			})
+		}
+
+		pretty, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return marshalResponse(responseEnvelope{
+				JSONRPC: "2.0",
+				ID:      rawIDToValue(req.ID),
+				Error:   &rpcError{Code: -32603, Message: "failed to encode tool result", Data: err.Error()},
+			})
+		}
+
+		return marshalResponse(responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      rawIDToValue(req.ID),
+			Result: map[string]interface{}{
+				"content":           []interface{}{map[string]interface{}{"type": "text", "text": string(pretty)}},
 				"structuredContent": result,
 				"isError":           false,
 			},
@@ -735,6 +1108,266 @@ func parseGitCountLineOptions(arguments map[string]interface{}) (gitCountLineOpt
 		return options, fmt.Errorf("endDate is required")
 	}
 
+	return options, nil
+}
+
+func runDockerShowImagesArch(arguments map[string]interface{}) (dockerShowImagesArchStructuredResult, error) {
+	options, err := parseDockerShowImagesArchOptions(arguments)
+	if err != nil {
+		return dockerShowImagesArchStructuredResult{}, err
+	}
+
+	scriptPath, err := resolveShellScript("SUSS_DOCKER_SHOW_IMAGES_ARCH_SCRIPT", "docker-show-images-arch.sh")
+	if err != nil {
+		return dockerShowImagesArchStructuredResult{}, err
+	}
+
+	args := []string{scriptPath, "--json"}
+	args = append(args, options.Images...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", args...)
+	if options.WorkingDirectory != "" {
+		cmd.Dir = options.WorkingDirectory
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderrText := strings.TrimSpace(string(exitErr.Stderr))
+			if stderrText == "" {
+				stderrText = exitErr.Error()
+			}
+			return dockerShowImagesArchStructuredResult{}, fmt.Errorf("docker_show_images_arch failed: %s", stderrText)
+		}
+		return dockerShowImagesArchStructuredResult{}, fmt.Errorf("docker_show_images_arch execution failed: %w", err)
+	}
+
+	var parsed dockerShowImagesArchScriptResult
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return dockerShowImagesArchStructuredResult{}, fmt.Errorf("invalid JSON from docker-show-images-arch script: %w", err)
+	}
+
+	images := make([]dockerShowImagesArchStructuredImage, 0, len(parsed.Images))
+	for _, image := range parsed.Images {
+		images = append(images, dockerShowImagesArchStructuredImage{
+			ID:           image.ID,
+			RepoTags:     image.RepoTags,
+			Architecture: image.Architecture,
+			OS:           image.OS,
+			Variant:      image.Variant,
+		})
+	}
+
+	return dockerShowImagesArchStructuredResult{
+		OK:     parsed.OK,
+		Images: images,
+	}, nil
+}
+
+func parseDockerShowImagesArchOptions(arguments map[string]interface{}) (dockerShowImagesArchOptions, error) {
+	options := dockerShowImagesArchOptions{}
+	if len(arguments) == 0 {
+		return options, nil
+	}
+
+	if value, ok := arguments["images"]; ok {
+		images, err := toStringSlice(value)
+		if err != nil {
+			return options, fmt.Errorf("images must be a string or array of strings")
+		}
+		options.Images = images
+	}
+	if value, ok := firstValue(arguments, "workingDirectory", "working_directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("workingDirectory must be a string")
+		}
+		options.WorkingDirectory = stringValue
+	}
+	return options, nil
+}
+
+func runGitStatusSubdir(arguments map[string]interface{}) (gitStatusSubdirStructuredResult, error) {
+	options, err := parseGitStatusSubdirOptions(arguments)
+	if err != nil {
+		return gitStatusSubdirStructuredResult{}, err
+	}
+
+	scriptPath, err := resolveShellScript("SUSS_GIT_STATUS_SUBDIR_SCRIPT", "git-status-subdir.sh")
+	if err != nil {
+		return gitStatusSubdirStructuredResult{}, err
+	}
+
+	args := []string{scriptPath, "--json", "--directory", options.Directory, "--depth", strconv.Itoa(options.Depth)}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", args...)
+	if options.WorkingDirectory != "" {
+		cmd.Dir = options.WorkingDirectory
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderrText := strings.TrimSpace(string(exitErr.Stderr))
+			if stderrText == "" {
+				stderrText = exitErr.Error()
+			}
+			return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdir failed: %s", stderrText)
+		}
+		return gitStatusSubdirStructuredResult{}, fmt.Errorf("git_status_subdir execution failed: %w", err)
+	}
+
+	var parsed gitStatusSubdirScriptResult
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return gitStatusSubdirStructuredResult{}, fmt.Errorf("invalid JSON from git-status-subdir script: %w", err)
+	}
+
+	repositories := make([]gitStatusSubdirStructuredRepository, 0, len(parsed.Repositories))
+	for _, repo := range parsed.Repositories {
+		repositories = append(repositories, gitStatusSubdirStructuredRepository{
+			Path:            repo.Path,
+			RelativePath:    repo.RelativePath,
+			Branch:          repo.Branch,
+			Upstream:        repo.Upstream,
+			Ahead:           repo.Ahead,
+			Behind:          repo.Behind,
+			StagedCount:     repo.StagedCount,
+			UnstagedCount:   repo.UnstagedCount,
+			UntrackedCount:  repo.UntrackedCount,
+			ConflictedCount: repo.ConflictedCount,
+			Clean:           repo.Clean,
+		})
+	}
+
+	return gitStatusSubdirStructuredResult{
+		OK:           parsed.OK,
+		Directory:    parsed.Directory,
+		Depth:        parsed.Depth,
+		Repositories: repositories,
+	}, nil
+}
+
+func parseGitStatusSubdirOptions(arguments map[string]interface{}) (gitStatusSubdirOptions, error) {
+	options := gitStatusSubdirOptions{
+		Directory: ".",
+		Depth:     2,
+	}
+	if len(arguments) == 0 {
+		return options, nil
+	}
+	if value, ok := firstValue(arguments, "directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok || stringValue == "" {
+			return options, fmt.Errorf("directory must be a non-empty string")
+		}
+		options.Directory = stringValue
+	}
+	if value, ok := firstValue(arguments, "depth"); ok {
+		intValue, err := toInt(value)
+		if err != nil || intValue < 0 {
+			return options, fmt.Errorf("depth must be a non-negative integer")
+		}
+		options.Depth = intValue
+	}
+	if value, ok := firstValue(arguments, "workingDirectory", "working_directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("workingDirectory must be a string")
+		}
+		options.WorkingDirectory = stringValue
+	}
+	return options, nil
+}
+
+func runWatchProgramMemory(arguments map[string]interface{}) (watchProgramMemoryStructuredResult, error) {
+	options, err := parseWatchProgramMemoryOptions(arguments)
+	if err != nil {
+		return watchProgramMemoryStructuredResult{}, err
+	}
+
+	scriptPath, err := resolveShellScript("SUSS_WATCH_PROGRAM_MEMORY_SCRIPT", "watch-prog-memory.sh")
+	if err != nil {
+		return watchProgramMemoryStructuredResult{}, err
+	}
+
+	args := []string{scriptPath, "--json", "--program", options.Program}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", args...)
+	if options.WorkingDirectory != "" {
+		cmd.Dir = options.WorkingDirectory
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderrText := strings.TrimSpace(string(exitErr.Stderr))
+			if stderrText == "" {
+				stderrText = exitErr.Error()
+			}
+			return watchProgramMemoryStructuredResult{}, fmt.Errorf("watch_program_memory failed: %s", stderrText)
+		}
+		return watchProgramMemoryStructuredResult{}, fmt.Errorf("watch_program_memory execution failed: %w", err)
+	}
+
+	var parsed watchProgramMemoryScriptResult
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return watchProgramMemoryStructuredResult{}, fmt.Errorf("invalid JSON from watch-prog-memory script: %w", err)
+	}
+
+	processes := make([]watchProgramMemoryStructuredProcess, 0, len(parsed.Processes))
+	for _, process := range parsed.Processes {
+		processes = append(processes, watchProgramMemoryStructuredProcess{
+			PID:     process.PID,
+			RSSKB:   process.RSSKB,
+			Command: process.Command,
+			Args:    process.Args,
+		})
+	}
+
+	return watchProgramMemoryStructuredResult{
+		OK:         parsed.OK,
+		Timestamp:  parsed.Timestamp,
+		Program:    parsed.Program,
+		MatchCount: parsed.MatchCount,
+		TotalRSSKB: parsed.TotalRSSKB,
+		Processes:  processes,
+	}, nil
+}
+
+func parseWatchProgramMemoryOptions(arguments map[string]interface{}) (watchProgramMemoryOptions, error) {
+	options := watchProgramMemoryOptions{}
+	if len(arguments) == 0 {
+		return options, fmt.Errorf("program is required")
+	}
+	if value, ok := firstValue(arguments, "program"); ok {
+		stringValue, ok := value.(string)
+		if !ok || stringValue == "" {
+			return options, fmt.Errorf("program must be a non-empty string")
+		}
+		options.Program = stringValue
+	}
+	if value, ok := firstValue(arguments, "workingDirectory", "working_directory"); ok {
+		stringValue, ok := value.(string)
+		if !ok {
+			return options, fmt.Errorf("workingDirectory must be a string")
+		}
+		options.WorkingDirectory = stringValue
+	}
+	if options.Program == "" {
+		return options, fmt.Errorf("program is required")
+	}
 	return options, nil
 }
 

--- a/mcp/cmd/someuseful-mcp/main_test.go
+++ b/mcp/cmd/someuseful-mcp/main_test.go
@@ -98,3 +98,68 @@ func TestNegotiateProtocolVersion(t *testing.T) {
 		t.Fatalf("expected fallback to latest protocol version, got %s", got)
 	}
 }
+
+func TestParseDockerShowImagesArchOptionsDefaults(t *testing.T) {
+	options, err := parseDockerShowImagesArchOptions(nil)
+	if err != nil {
+		t.Fatalf("parseDockerShowImagesArchOptions returned error: %v", err)
+	}
+	if len(options.Images) != 0 {
+		t.Fatalf("expected empty default images, got %#v", options.Images)
+	}
+}
+
+func TestParseGitStatusSubdirOptionsDefaults(t *testing.T) {
+	options, err := parseGitStatusSubdirOptions(nil)
+	if err != nil {
+		t.Fatalf("parseGitStatusSubdirOptions returned error: %v", err)
+	}
+	if options.Directory != "." {
+		t.Fatalf("unexpected default directory: %s", options.Directory)
+	}
+	if options.Depth != 2 {
+		t.Fatalf("unexpected default depth: %d", options.Depth)
+	}
+}
+
+func TestParseGitStatusSubdirOptionsAliases(t *testing.T) {
+	options, err := parseGitStatusSubdirOptions(map[string]interface{}{
+		"directory":         "/tmp/workspace",
+		"depth":             float64(3),
+		"working_directory": "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("parseGitStatusSubdirOptions returned error: %v", err)
+	}
+	if options.Directory != "/tmp/workspace" {
+		t.Fatalf("unexpected directory: %s", options.Directory)
+	}
+	if options.Depth != 3 {
+		t.Fatalf("unexpected depth: %d", options.Depth)
+	}
+	if options.WorkingDirectory != "/tmp" {
+		t.Fatalf("unexpected working directory: %s", options.WorkingDirectory)
+	}
+}
+
+func TestParseWatchProgramMemoryOptionsRequired(t *testing.T) {
+	if _, err := parseWatchProgramMemoryOptions(nil); err == nil {
+		t.Fatalf("expected missing program to fail")
+	}
+}
+
+func TestParseWatchProgramMemoryOptionsAliases(t *testing.T) {
+	options, err := parseWatchProgramMemoryOptions(map[string]interface{}{
+		"program":           "claude",
+		"working_directory": "/tmp",
+	})
+	if err != nil {
+		t.Fatalf("parseWatchProgramMemoryOptions returned error: %v", err)
+	}
+	if options.Program != "claude" {
+		t.Fatalf("unexpected program: %s", options.Program)
+	}
+	if options.WorkingDirectory != "/tmp" {
+		t.Fatalf("unexpected working directory: %s", options.WorkingDirectory)
+	}
+}

--- a/shell/docker-show-images-arch.sh
+++ b/shell/docker-show-images-arch.sh
@@ -1,12 +1,132 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# show all images architecture
-images=$(docker image ls -q)
-if [ -z "${images}" ]; then
-    echo "no images found."
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common-cli.sh
+source "$SCRIPT_DIR/lib/common-cli.sh"
+
+PROGRAM_NAME=$(basename "$0")
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME [options] [IMAGE...]
+
+Show docker image architecture details for one or more images.
+
+Options:
+  -h, --help                  Show this help message.
+  -j, --json                  Print a JSON document instead of plain text.
+
+Examples:
+  $PROGRAM_NAME
+  $PROGRAM_NAME alpine:latest
+  $PROGRAM_NAME --json ubuntu:24.04 busybox
+EOF
+}
+
+json_array_from_csv() {
+    local csv=$1
+    local first=1
+    local item
+
+    printf '['
+    OLD_IFS=$IFS
+    IFS=','
+    for item in $csv; do
+        [ -n "$item" ] || continue
+        if [ $first -eq 0 ]; then
+            printf ','
+        fi
+        printf '"%s"' "$(suss_json_escape "$item")"
+        first=0
+    done
+    IFS=$OLD_IFS
+    printf ']'
+}
+
+JSON_OUTPUT=0
+IMAGES=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -j | --json)
+            JSON_OUTPUT=1
+            shift
+            ;;
+        --)
+            shift
+            while [ "$#" -gt 0 ]; do
+                IMAGES+=("$1")
+                shift
+            done
+            break
+            ;;
+        -*)
+            suss_die "$PROGRAM_NAME" "unknown option: $1"
+            ;;
+        *)
+            IMAGES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+suss_require_command "docker" "$PROGRAM_NAME"
+
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+    while IFS= read -r image_id; do
+        [ -n "$image_id" ] || continue
+        IMAGES+=("$image_id")
+    done < <(docker image ls -q | awk '!seen[$0]++')
+fi
+
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+    if [ "$JSON_OUTPUT" -eq 1 ]; then
+        printf '{\n'
+        printf '  "ok": true,\n'
+        printf '  "images": []\n'
+        printf '}\n'
+        exit 0
+    fi
+    printf 'no images found\n'
     exit 0
 fi
 
-docker inspect -f "{{.ID}} {{.RepoTags}} {{.Architecture}}" $images
+INSPECT_FILE=$(mktemp "${TMPDIR:-/tmp}/docker-show-images-arch.XXXXXX")
+trap 'rm -f "$INSPECT_FILE"' EXIT
+
+docker image inspect --format '{{.Id}}\t{{json .RepoTags}}\t{{.Architecture}}\t{{.Os}}\t{{.Variant}}' "${IMAGES[@]}" > "$INSPECT_FILE"
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '{\n'
+    printf '  "ok": true,\n'
+    printf '  "images": [\n'
+    first=1
+    while IFS=$'\t' read -r image_id repo_tags architecture os_name variant; do
+        [ -n "$image_id" ] || continue
+        if [ $first -eq 0 ]; then
+            printf ',\n'
+        fi
+        printf '    {\n'
+        printf '      "id": "%s",\n' "$(suss_json_escape "$image_id")"
+        printf '      "repo_tags": %s,\n' "${repo_tags:-[]}"
+        printf '      "architecture": "%s",\n' "$(suss_json_escape "$architecture")"
+        printf '      "os": "%s",\n' "$(suss_json_escape "$os_name")"
+        printf '      "variant": "%s"\n' "$(suss_json_escape "$variant")"
+        printf '    }'
+        first=0
+    done < "$INSPECT_FILE"
+    printf '\n  ]\n'
+    printf '}\n'
+    exit 0
+fi
+
+while IFS=$'\t' read -r image_id repo_tags architecture os_name variant; do
+    [ -n "$image_id" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\n' "$image_id" "$repo_tags" "$architecture" "$os_name" "$variant"
+done < "$INSPECT_FILE"

--- a/shell/git-status-subdir.sh
+++ b/shell/git-status-subdir.sh
@@ -1,17 +1,175 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
 
-if [ $# -lt 2 ]; then
-	echo "Usage: $0 {DIRECTORY} {DEPTH}"
-	exit 1
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common-cli.sh
+source "$SCRIPT_DIR/lib/common-cli.sh"
+
+PROGRAM_NAME=$(basename "$0")
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME [options]
+
+Inspect git repositories under a directory and summarize their working tree status.
+
+Options:
+  -h, --help                  Show this help message.
+  -j, --json                  Print a JSON document instead of plain text.
+  -d, --directory PATH        Root directory to scan. Defaults to current directory.
+      --depth N               Max directory depth to scan for nested repositories. Defaults to 2.
+
+Examples:
+  $PROGRAM_NAME
+  $PROGRAM_NAME --directory ~/workspace --depth 3
+  $PROGRAM_NAME --json -d . --depth 2
+EOF
+}
+
+JSON_OUTPUT=0
+DIRECTORY="."
+DEPTH=2
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -j | --json)
+            JSON_OUTPUT=1
+            shift
+            ;;
+        -d | --directory)
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --directory"
+            DIRECTORY=$2
+            shift 2
+            ;;
+        --directory=*)
+            DIRECTORY=${1#*=}
+            shift
+            ;;
+        --depth)
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --depth"
+            DEPTH=$2
+            shift 2
+            ;;
+        --depth=*)
+            DEPTH=${1#*=}
+            shift
+            ;;
+        -*)
+            suss_die "$PROGRAM_NAME" "unknown option: $1"
+            ;;
+        *)
+            suss_die "$PROGRAM_NAME" "unexpected positional argument: $1"
+            ;;
+    esac
+done
+
+[ -d "$DIRECTORY" ] || suss_die "$PROGRAM_NAME" "directory does not exist: $DIRECTORY"
+if ! suss_is_integer "$DEPTH" || [ "$DEPTH" -lt 0 ]; then
+    suss_die "$PROGRAM_NAME" "--depth must be a non-negative integer"
 fi
 
-DIRECTORY=$1
-DEPTH=$2
+ROOT_DIR=$(cd "$DIRECTORY" && pwd)
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/git-status-subdir.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-# perfect one
-find $DIRECTORY -type d -depth $DEPTH \
-	\! -name "\.*" \
-	-exec echo "Working directory: "{} \; \
-	-exec git --git-dir={}/.git --work-tree=$PWD/{} status \; \
-    -exec echo "" \;
+REPOS_FILE="$TMP_DIR/repos.txt"
+STATUS_FILE="$TMP_DIR/status.txt"
+
+if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    top_level=$(git -C "$ROOT_DIR" rev-parse --show-toplevel)
+    if [ "$top_level" = "$ROOT_DIR" ]; then
+        printf '%s\n' "$top_level" >> "$REPOS_FILE"
+    fi
+fi
+
+find "$ROOT_DIR" \
+    -type d -name .git -print \
+    -o \( -path '*/.*' -o -path '*/node_modules' \) -prune \
+    | while IFS= read -r git_dir; do
+        dirname "$git_dir"
+    done >> "$REPOS_FILE"
+
+sort -u "$REPOS_FILE" -o "$REPOS_FILE"
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '{\n'
+    printf '  "ok": true,\n'
+    printf '  "directory": "%s",\n' "$(suss_json_escape "$ROOT_DIR")"
+    printf '  "depth": %s,\n' "$DEPTH"
+    printf '  "repositories": [\n'
+fi
+
+first_repo=1
+while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+
+    relative_path=${repo#"$ROOT_DIR"/}
+    if [ "$repo" = "$ROOT_DIR" ]; then
+        relative_path="."
+    fi
+
+    repo_depth=0
+    if [ "$relative_path" != "." ]; then
+        repo_depth=$(printf '%s' "$relative_path" | awk -F/ '{print NF}')
+    fi
+    if [ "$repo_depth" -gt "$DEPTH" ]; then
+        continue
+    fi
+
+    git -C "$repo" status --porcelain=2 --branch > "$STATUS_FILE"
+
+    branch=$(awk '/^# branch.head / {print $3; exit}' "$STATUS_FILE")
+    [ -n "$branch" ] || branch="HEAD"
+
+    upstream=$(awk '/^# branch.upstream / {print $3; exit}' "$STATUS_FILE")
+    ahead=0
+    behind=0
+    ab_line=$(awk '/^# branch.ab / {print $0; exit}' "$STATUS_FILE")
+    if [ -n "$ab_line" ]; then
+        ahead=$(printf '%s\n' "$ab_line" | awk '{sub(/^\+/,"",$3); print $3 + 0}')
+        behind=$(printf '%s\n' "$ab_line" | awk '{sub(/^-/,"",$4); print $4 + 0}')
+    fi
+
+    staged_count=$(awk '/^1 / || /^2 / {if (substr($3,1,1) != ".") c++} END {print c + 0}' "$STATUS_FILE")
+    unstaged_count=$(awk '/^1 / || /^2 / {if (substr($3,2,1) != ".") c++} END {print c + 0}' "$STATUS_FILE")
+    untracked_count=$(awk '/^\? / {c++} END {print c + 0}' "$STATUS_FILE")
+    conflicted_count=$(awk '/^u / {c++} END {print c + 0}' "$STATUS_FILE")
+    clean=true
+    if [ "$staged_count" -gt 0 ] || [ "$unstaged_count" -gt 0 ] || [ "$untracked_count" -gt 0 ] || [ "$conflicted_count" -gt 0 ]; then
+        clean=false
+    fi
+
+    if [ "$JSON_OUTPUT" -eq 1 ]; then
+        if [ $first_repo -eq 0 ]; then
+            printf ',\n'
+        fi
+        printf '    {\n'
+        printf '      "path": "%s",\n' "$(suss_json_escape "$repo")"
+        printf '      "relative_path": "%s",\n' "$(suss_json_escape "$relative_path")"
+        printf '      "branch": "%s",\n' "$(suss_json_escape "$branch")"
+        printf '      "upstream": "%s",\n' "$(suss_json_escape "$upstream")"
+        printf '      "ahead": %s,\n' "$ahead"
+        printf '      "behind": %s,\n' "$behind"
+        printf '      "staged_count": %s,\n' "$staged_count"
+        printf '      "unstaged_count": %s,\n' "$unstaged_count"
+        printf '      "untracked_count": %s,\n' "$untracked_count"
+        printf '      "conflicted_count": %s,\n' "$conflicted_count"
+        printf '      "clean": %s\n' "$clean"
+        printf '    }'
+        first_repo=0
+        continue
+    fi
+
+    printf '[%s] branch=%s upstream=%s ahead=%s behind=%s staged=%s unstaged=%s untracked=%s conflicted=%s clean=%s\n' \
+        "$relative_path" "$branch" "$upstream" "$ahead" "$behind" "$staged_count" "$unstaged_count" "$untracked_count" "$conflicted_count" "$clean"
+done < "$REPOS_FILE"
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '\n  ]\n'
+    printf '}\n'
+fi

--- a/shell/git-status-subdir.sh
+++ b/shell/git-status-subdir.sh
@@ -88,7 +88,7 @@ if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 find "$ROOT_DIR" \
-    -type d -name .git -print \
+    \( -type d -o -type f \) -name .git -print \
     -o \( -path '*/.*' -o -path '*/node_modules' \) -prune \
     | while IFS= read -r git_dir; do
         dirname "$git_dir"

--- a/shell/watch-prog-memory.sh
+++ b/shell/watch-prog-memory.sh
@@ -1,31 +1,164 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# make sure pidstat is installed. If not, make sure to install sysstat package.
-if ! command -v pidstat &> /dev/null
-then
-    # If it's in MacOS, suggest installing via brew
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "Could not find pidstat, please install sysstat package via 'brew install sysstat'."
-        echo "Then run it in crontab with: */1 * * * * $0 <program_name> [/path/to/output.log]"
-        exit 1
-    else
-        echo "Could not find pidstat, please install sysstat package."
-        echo "Then run it in crontab with: */1 * * * * $0 <program_name> [/path/to/output.log]"
-        exit 1
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common-cli.sh
+source "$SCRIPT_DIR/lib/common-cli.sh"
+
+PROGRAM_NAME=$(basename "$0")
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME [options]
+
+Sample RSS memory usage for processes matching a program name.
+
+Options:
+  -h, --help                  Show this help message.
+  -j, --json                  Print a JSON document instead of plain text.
+  -p, --program NAME          Program name or pattern to match.
+  -o, --output-file PATH      Append a TSV snapshot to a log file.
+      --dry-run               Show what would be written without touching the output file.
+
+Examples:
+  $PROGRAM_NAME --program postgres
+  $PROGRAM_NAME --json -p claude
+  $PROGRAM_NAME -p redis-server --output-file /tmp/redis-memory.tsv
+EOF
+}
+
+JSON_OUTPUT=0
+PROGRAM_PATTERN=""
+OUTPUT_FILE=""
+DRY_RUN=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -j | --json)
+            JSON_OUTPUT=1
+            shift
+            ;;
+        -p | --program)
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --program"
+            PROGRAM_PATTERN=$2
+            shift 2
+            ;;
+        --program=*)
+            PROGRAM_PATTERN=${1#*=}
+            shift
+            ;;
+        -o | --output-file)
+            [ "$#" -ge 2 ] || suss_die "$PROGRAM_NAME" "missing value for --output-file"
+            OUTPUT_FILE=$2
+            shift 2
+            ;;
+        --output-file=*)
+            OUTPUT_FILE=${1#*=}
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -*)
+            suss_die "$PROGRAM_NAME" "unknown option: $1"
+            ;;
+        *)
+            if [ -z "$PROGRAM_PATTERN" ]; then
+                PROGRAM_PATTERN=$1
+                shift
+                continue
+            fi
+            suss_die "$PROGRAM_NAME" "unexpected positional argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$PROGRAM_PATTERN" ] || suss_die "$PROGRAM_NAME" "program name is required"
+suss_require_command "ps" "$PROGRAM_NAME"
+
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
+TMP_FILE=$(mktemp "${TMPDIR:-/tmp}/watch-prog-memory.XXXXXX")
+trap 'rm -f "$TMP_FILE"' EXIT
+
+ps -Ao pid=,rss=,comm=,args= \
+    | awk -v pattern="$PROGRAM_PATTERN" -v self_pid="$$" '
+        index($0, pattern) > 0 && $1 != self_pid && $3 != "awk" {
+            pid = $1
+            rss = $2
+            command = $3
+            $1 = ""
+            $2 = ""
+            $3 = ""
+            sub(/^[[:space:]]+/, "", $0)
+            printf "%s\t%s\t%s\t%s\n", pid, rss, command, $0
+        }
+    ' > "$TMP_FILE"
+
+match_count=$(awk 'END {print NR + 0}' "$TMP_FILE")
+total_rss_kb=$(awk -F '\t' '{sum += $2} END {print sum + 0}' "$TMP_FILE")
+
+if [ -n "$OUTPUT_FILE" ]; then
+    log_line=$(printf '%s\t%s\t%s\n' "$TIMESTAMP" "$PROGRAM_PATTERN" "$total_rss_kb")
+    if [ "$DRY_RUN" -eq 0 ]; then
+        mkdir -p "$(dirname "$OUTPUT_FILE")"
+        printf '%s\n' "$log_line" >> "$OUTPUT_FILE"
     fi
 fi
 
-prog_name=$1
-if [ -z "$prog_name" ]; then
-    echo "Usage: $0 <program_name>"
-    exit 1
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+    printf '{\n'
+    printf '  "ok": true,\n'
+    printf '  "timestamp": "%s",\n' "$(suss_json_escape "$TIMESTAMP")"
+    printf '  "program": "%s",\n' "$(suss_json_escape "$PROGRAM_PATTERN")"
+    printf '  "match_count": %s,\n' "$match_count"
+    printf '  "total_rss_kb": %s,\n' "$total_rss_kb"
+    if [ -n "$OUTPUT_FILE" ]; then
+        printf '  "output_file": "%s",\n' "$(suss_json_escape "$OUTPUT_FILE")"
+        if [ "$DRY_RUN" -eq 1 ]; then
+            printf '  "dry_run": true,\n'
+        else
+            printf '  "dry_run": false,\n'
+        fi
+    fi
+    printf '  "processes": [\n'
+    first=1
+    while IFS=$'\t' read -r pid rss_kb command args; do
+        [ -n "$pid" ] || continue
+        if [ $first -eq 0 ]; then
+            printf ',\n'
+        fi
+        printf '    {\n'
+        printf '      "pid": %s,\n' "$pid"
+        printf '      "rss_kb": %s,\n' "$rss_kb"
+        printf '      "command": "%s",\n' "$(suss_json_escape "$command")"
+        printf '      "args": "%s"\n' "$(suss_json_escape "$args")"
+        printf '    }'
+        first=0
+    done < "$TMP_FILE"
+    printf '\n  ]\n'
+    printf '}\n'
+    exit 0
 fi
 
-output_file=${2:-/tmp/memory/$prog_name.log}
-mkdir -p $(dirname $output_file)
+printf 'timestamp: %s\n' "$TIMESTAMP"
+printf 'program: %s\n' "$PROGRAM_PATTERN"
+printf 'matched processes: %s\n' "$match_count"
+printf 'total rss (KB): %s\n' "$total_rss_kb"
+if [ -n "$OUTPUT_FILE" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf 'dry run log target: %s\n' "$OUTPUT_FILE"
+    else
+        printf 'log appended: %s\n' "$OUTPUT_FILE"
+    fi
+fi
 
-prog_mem=$(pidstat  -r -u -h -C $prog_name |awk 'NR==4{print $12}')
-time=$(date "+%Y-%m-%d %H:%M:%S")
-echo $time"\tmemory(Byte)\t"$prog_mem >>$output_file
+while IFS=$'\t' read -r pid rss_kb command args; do
+    [ -n "$pid" ] || continue
+    printf 'pid=%s rss_kb=%s command=%s args=%s\n' "$pid" "$rss_kb" "$command" "$args"
+done < "$TMP_FILE"


### PR DESCRIPTION
## Summary
- stabilize `docker-show-images-arch.sh` as a structured read-only CLI
- rewrite `git-status-subdir.sh` and `watch-prog-memory.sh` with help/json contracts
- expose the three tools from the MCP server and document their schemas

## Testing
- `bash -n shell/docker-show-images-arch.sh shell/git-status-subdir.sh shell/watch-prog-memory.sh shell/go-list-dep.sh shell/git-count-line.sh`
- `(cd mcp && go test ./...)`
- `shell/git-status-subdir.sh --json --directory . --depth 1`
- `shell/watch-prog-memory.sh --json --program zsh`