### PR TITLE
Add guarded github-release-ops skill

### DIFF
--- a/docs/script-inventory.md
+++ b/docs/script-inventory.md
@@ -46,7 +46,7 @@
 | `shell/docker-show-images-arch.sh` | docker | 查看镜像架构 | `docker` | L | rewrite | MCP | 非常适合先做 MCP |
 | `shell/du-dir.sh` | filesystem | 查看目录体积 | `du`, `sort` | L | rewrite | MCP | 需要修复 glob/空目录兼容性 |
 | `shell/eth-keystore-2-privatekey.sh` | ethereum | keystore 导出私钥 | `node`, `npm` | H | rewrite | Local-only | 涉及私钥，不建议暴露给通用 Agent |
-| `shell/gh-delete-oudate-actions.sh` | GitHub Actions | 删除过期 workflow runs | `gh` | H | rewrite | Skill | 需要分页、dry-run、确认机制 |
+| `shell/gh-delete-oudate-actions.sh` | GitHub Actions | 删除过期 workflow runs | `gh` | H | keep | Skill | 已完成分页、dry-run、显式确认加固；适合作为 guarded skill 的底层命令 |
 | `shell/gh-post-release-example.sh` | GitHub release | tag push 后构建并上传 release | `make`, `gh-upload-release.sh` | M | archive | Archive | 更像历史示例，不像通用工具 |
 | `shell/gh-upload-release.sh` | GitHub release | 创建 release 并上传产物 | `git`, `github-release`, `go` | H | rewrite | Skill | 逻辑有价值，但实现老旧且有 `eval` 风险 |
 | `shell/git-clean-after-rm.sh` | git maintenance | 清理 refs/reflog/gc | `git` | H | keep | Local-only | 可保留为手工维护命令 |
@@ -110,4 +110,3 @@
 
 - 本地手工命令；
 - 或者仅被带强确认的 skill 间接调用。
-

--- a/skills/github-release-ops/SKILL.md
+++ b/skills/github-release-ops/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: github-release-ops
+description: Guarded GitHub release-adjacent operations limited to dry-run-first cleanup of outdated Actions runs
+---
+
+# github-release-ops
+
+## Purpose / Scope
+
+Use this skill for a guarded first slice of GitHub release-adjacent repository operations.
+
+This slice is intentionally narrow. It is for:
+
+- dry-run-first inspection of outdated GitHub Actions workflow runs
+- optional deletion of outdated workflow runs only after explicit destructive confirmation
+- concise operator guidance about what remains manual
+
+It is not for full release automation.
+
+## Preconditions
+
+Before using this skill, confirm all of the following:
+
+- `shell/gh-delete-oudate-actions.sh` exists and is the only automation-ready command allowed in this slice
+- the operator has explicit values for `owner`, `repo`, and `cutoff-epoch`
+- `owner`, `repo`, and `cutoff-epoch` are passed explicitly and not inferred from git remotes, tags, or surrounding context
+- the first execution is a dry run
+
+If any required input is missing, stop and ask for the missing value instead of guessing.
+
+## Allowed Command Surface
+
+Only this command is allowed in this slice:
+
+- `shell/gh-delete-oudate-actions.sh`
+  - required flags: `--owner`, `--repo`, `--cutoff-epoch`
+  - required first mode: `--dry-run`
+  - only allowed destructive mode: `--execute --yes`
+
+Recommended command forms:
+
+- dry run:
+  - `shell/gh-delete-oudate-actions.sh --dry-run --owner <owner> --repo <repo> --cutoff-epoch <unix-seconds>`
+- destructive execution, only after explicit confirmation:
+  - `shell/gh-delete-oudate-actions.sh --execute --yes --owner <owner> --repo <repo> --cutoff-epoch <unix-seconds>`
+
+## Forbidden Actions
+
+This skill must not perform, invoke, or recommend by default:
+
+- `shell/gh-upload-release.sh`
+- `shell/git-tag-with-logs.sh`
+- release creation
+- tag creation or publication
+- asset upload
+- broader GitHub release workflow automation
+- destructive execution without explicit confirmation matching `--execute --yes`
+- skipping the dry-run step
+- inferring or defaulting `owner`, `repo`, or `cutoff-epoch`
+
+Release creation, tag publication, and asset upload remain manual and blocked in this first slice.
+
+## Workflow Steps
+
+1. Confirm the request fits the narrow scope of outdated GitHub Actions workflow-run cleanup.
+2. Confirm the operator has provided explicit `owner`, `repo`, and `cutoff-epoch` values.
+3. Run only the dry-run form first:
+   - `shell/gh-delete-oudate-actions.sh --dry-run --owner <owner> --repo <repo> --cutoff-epoch <unix-seconds>`
+4. Summarize the dry-run findings clearly:
+   - target repository
+   - cutoff used
+   - whether matching runs were found
+   - whether destructive execution is still blocked pending explicit confirmation
+5. Only if the operator explicitly confirms destructive execution with the exact destructive intent matching `--execute --yes`, run:
+   - `shell/gh-delete-oudate-actions.sh --execute --yes --owner <owner> --repo <repo> --cutoff-epoch <unix-seconds>`
+6. After destructive execution, report what was attempted and what the script reported.
+7. If the request expands into release creation, tag publication, or asset upload, stop and state that those operations are manual and blocked in this slice.
+
+## Output Contract
+
+Return a concise operations report with these parts:
+
+- `Scope`
+  - which repository and cutoff were targeted
+- `Inputs`
+  - the explicit `owner`, `repo`, and `cutoff-epoch` values used
+- `Mode`
+  - `dry-run` or `execute`
+- `Findings`
+  - what the script reported
+- `Blocked Operations`
+  - include this section when release creation, tagging, or upload work was requested or discussed
+- `Next Manual Step`
+  - include this section when broader release work remains outside this slice
+
+The report must distinguish between evidence from the script and blocked manual-only operations.
+
+## Escalation Rules
+
+Escalate instead of continuing when:
+
+- `owner`, `repo`, or `cutoff-epoch` is missing
+- the user asks to skip the dry run
+- the user asks for destructive execution without explicit confirmation matching `--execute --yes`
+- the user asks to invoke or recommend `shell/gh-upload-release.sh`
+- the user asks to invoke or recommend `shell/git-tag-with-logs.sh`
+- the request shifts into release creation, tag publication, asset upload, or broader release automation
+- the command surface needed is larger than `shell/gh-delete-oudate-actions.sh`
+
+When escalating, say what is allowed in this slice, what is blocked, and which manual step or later skill slice would be required next.


### PR DESCRIPTION
## Summary
- add the first guarded `github-release-ops` skill around the hardened Actions cleanup CLI
- require explicit `owner` / `repo` / `cutoff-epoch`, dry-run first, and explicit `--execute --yes` confirmation for destructive cleanup
- correct the `script-inventory` row so it matches the post-hardening state of `gh-delete-oudate-actions.sh`

## Verification
- `git diff --check`
- contract grep on `skills/github-release-ops/SKILL.md` for required sections and cleanup safety gates
- targeted row verification in `docs/script-inventory.md`
- architect verification: APPROVED
